### PR TITLE
New framework structure, nJet cut and cleaning

### DIFF
--- a/interface/Categories.h
+++ b/interface/Categories.h
@@ -6,18 +6,8 @@
 
 class DileptonCategory: public Category {
     public:
-        virtual void configure(const edm::ParameterSet& conf) override {
-            m_mll_cut = conf.getUntrackedParameter<double>("mll_cut", 20);
-            m_mll_lowerZcut = conf.getUntrackedParameter<double>("mll_lowerZcut", 85);
-        }
         const std::vector<HH::Lepton>& getLeptons(const AnalyzersManager& analyzers) const ;
         const std::vector<HH::Dilepton>& getDileptons(const AnalyzersManager& analyzers) const ;
-        const unsigned int getNJets(const AnalyzersManager& analyzers) const ;
-        const unsigned int getNBJets(const AnalyzersManager& analyzers) const ;
-
-    protected:
-        float m_mll_cut;
-        float m_mll_lowerZcut;
 };
 
 class MuMuCategory: public DileptonCategory {

--- a/plugins/Categories.cc
+++ b/plugins/Categories.cc
@@ -38,7 +38,7 @@ const unsigned int DileptonCategory::getNBJets(const AnalyzersManager& analyzers
 bool MuMuCategory::event_in_category_pre_analyzers(const ProducersManager& producers) const {
     const MuonsProducer& muons = producers.get<MuonsProducer>("muons");
     const JetsProducer& alljets = producers.get<JetsProducer>("jets");
-    return (muons.p4.size() >= 2 && alljets.p4.size() >= 2);
+    return (muons.p4.size() >= 2);
 };
 
 bool MuMuCategory::event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const {
@@ -48,8 +48,7 @@ bool MuMuCategory::event_in_category_post_analyzers(const ProducersManager& prod
     {
         if (ll[idilep].isMuMu) isMuMu = true;
     }
-    const unsigned int nJets = getNJets(analyzers);
-    return (isMuMu && nJets >= 2);
+    return (isMuMu);
 };
 
 void MuMuCategory::register_cuts(CutManager& manager) {
@@ -87,7 +86,7 @@ void MuMuCategory::evaluate_cuts_post_analyzers(CutManager& manager, const Produ
 bool ElElCategory::event_in_category_pre_analyzers(const ProducersManager& producers) const {
     const ElectronsProducer& electrons = producers.get<ElectronsProducer>("electrons");
     const JetsProducer& alljets = producers.get<JetsProducer>("jets");
-    return (electrons.p4.size() >= 2  && alljets.p4.size() >= 2);
+    return (electrons.p4.size() >= 2);
 };
 
 bool ElElCategory::event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const {
@@ -97,8 +96,7 @@ bool ElElCategory::event_in_category_post_analyzers(const ProducersManager& prod
     {
         if (ll[idilep].isElEl) isElEl = true;
     }
-    const unsigned int nJets = getNJets(analyzers);
-    return (isElEl && nJets >= 2);
+    return (isElEl);
 };
 
 void ElElCategory::register_cuts(CutManager& manager) {
@@ -135,7 +133,7 @@ bool ElMuCategory::event_in_category_pre_analyzers(const ProducersManager& produ
     const ElectronsProducer& electrons = producers.get<ElectronsProducer>("electrons");
     const MuonsProducer& muons = producers.get<MuonsProducer>("muons");
     const JetsProducer& alljets = producers.get<JetsProducer>("jets");
-    return ((electrons.p4.size() + muons.p4.size() >= 2)  && alljets.p4.size() >= 2);
+    return ((electrons.p4.size() + muons.p4.size()) >= 2);
 };
 
 bool ElMuCategory::event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const {
@@ -145,8 +143,7 @@ bool ElMuCategory::event_in_category_post_analyzers(const ProducersManager& prod
     {
         if (ll[idilep].isElMu) isElMu = true;
     }
-    const unsigned int nJets = getNJets(analyzers);
-    return (isElMu && nJets >= 2);
+    return (isElMu);
 };
 
 void ElMuCategory::register_cuts(CutManager& manager) {
@@ -181,7 +178,7 @@ bool MuElCategory::event_in_category_pre_analyzers(const ProducersManager& produ
     const ElectronsProducer& electrons = producers.get<ElectronsProducer>("electrons");
     const MuonsProducer& muons = producers.get<MuonsProducer>("muons");
     const JetsProducer& alljets = producers.get<JetsProducer>("jets");
-    return ((electrons.p4.size() + muons.p4.size() >= 2)  && alljets.p4.size() >= 2);
+    return ((electrons.p4.size() + muons.p4.size()) >= 2);
 };
 
 bool MuElCategory::event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const {
@@ -191,8 +188,7 @@ bool MuElCategory::event_in_category_post_analyzers(const ProducersManager& prod
     {
         if (ll[idilep].isMuEl) isMuEl = true;
     }
-    const unsigned int nJets = getNJets(analyzers);
-    return (isMuEl && nJets >= 2);
+    return (isMuEl);
 };
 
 void MuElCategory::register_cuts(CutManager& manager) {

--- a/plugins/Categories.cc
+++ b/plugins/Categories.cc
@@ -1,12 +1,8 @@
 #include <cp3_llbb/Framework/interface/MuonsProducer.h>
 #include <cp3_llbb/Framework/interface/ElectronsProducer.h>
-#include <cp3_llbb/Framework/interface/JetsProducer.h>
 #include <cp3_llbb/Framework/interface/HLTProducer.h>
 
 #include <cp3_llbb/HHAnalysis/interface/Categories.h>
-
-// NB : All di-lepton categories require also two jets, as we do not want to store events without at least two leptons and two jets.
-//      The criteria "having two b-jets" is passed as a cut in the category in question.
 
 // ***** ***** *****
 // Dilepton categories
@@ -22,22 +18,11 @@ const std::vector<HH::Dilepton>& DileptonCategory::getDileptons(const AnalyzersM
     return hh_analyzer.ll;
 }
 
-const unsigned int DileptonCategory::getNJets(const AnalyzersManager& analyzers) const {
-    const HHAnalyzer& hh_analyzer = analyzers.get<HHAnalyzer>("hh_analyzer");
-    return hh_analyzer.nJets;
-}
-
-const unsigned int DileptonCategory::getNBJets(const AnalyzersManager& analyzers) const {
-    const HHAnalyzer& hh_analyzer = analyzers.get<HHAnalyzer>("hh_analyzer");
-    return hh_analyzer.nBJetsM;
-}
-
 // ***** ***** *****
 // Dilepton Mu-Mu category
 // ***** ***** *****
 bool MuMuCategory::event_in_category_pre_analyzers(const ProducersManager& producers) const {
     const MuonsProducer& muons = producers.get<MuonsProducer>("muons");
-    const JetsProducer& alljets = producers.get<JetsProducer>("jets");
     return (muons.p4.size() >= 2);
 };
 
@@ -52,25 +37,12 @@ bool MuMuCategory::event_in_category_post_analyzers(const ProducersManager& prod
 };
 
 void MuMuCategory::register_cuts(CutManager& manager) {
-    manager.new_cut("ll_mass", "mll > 20");
-    manager.new_cut("ll_mass_lowerZcut", "mll > 85");
-    manager.new_cut("has_two_bJets", "nBJetM >= 2");
     manager.new_cut("fire_trigger_Mu17_Mu8", "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*");
     manager.new_cut("fire_trigger_Mu17_TkMu8", "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v*");
     manager.new_cut("fire_trigger_IsoMu27", "HLT_IsoMu27_v*");
 };
 
 void MuMuCategory::evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {
-    const std::vector<HH::Dilepton>& ll = getDileptons(analyzers);
-    for (unsigned int idilep = 0; idilep < ll.size(); idilep++) 
-    {
-        if (ll[idilep].isMuMu) {
-            if (ll[idilep].p4.M() > m_mll_cut) manager.pass_cut("ll_mass");
-            if (ll[idilep].p4.M() > m_mll_lowerZcut) manager.pass_cut("ll_mass_lowerZcut");
-        }
-    }
-    const unsigned int nBJets = getNBJets(analyzers);
-    if (nBJets >=2) manager.pass_cut("has_two_bJets"); 
     const HLTProducer& hlt = producers.get<HLTProducer>("hlt");
     for (const std::string& path: hlt.paths) 
     {
@@ -85,7 +57,6 @@ void MuMuCategory::evaluate_cuts_post_analyzers(CutManager& manager, const Produ
 // ***** ***** *****
 bool ElElCategory::event_in_category_pre_analyzers(const ProducersManager& producers) const {
     const ElectronsProducer& electrons = producers.get<ElectronsProducer>("electrons");
-    const JetsProducer& alljets = producers.get<JetsProducer>("jets");
     return (electrons.p4.size() >= 2);
 };
 
@@ -100,24 +71,11 @@ bool ElElCategory::event_in_category_post_analyzers(const ProducersManager& prod
 };
 
 void ElElCategory::register_cuts(CutManager& manager) {
-    manager.new_cut("ll_mass", "mll > 20");
-    manager.new_cut("ll_mass_lowerZcut", "mll > 85");
-    manager.new_cut("has_two_bJets", "nBJet >= 2");
     manager.new_cut("fire_trigger_Ele17_Ele12", "HLT_Ele17_Ele12_CaloIdL_TrackIdL_IsoVL_DZ*");
     //manager.new_cut("fire_trigger_Ele23_WPLoose", "HLT_Ele23_WPLoose_Gsf_v*");
 };
 
 void ElElCategory::evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {
-    const std::vector<HH::Dilepton>& ll = getDileptons(analyzers);
-    for (unsigned int idilep = 0; idilep < ll.size(); idilep++) 
-    {
-        if (ll[idilep].isElEl) {
-            if (ll[idilep].p4.M() > m_mll_cut) manager.pass_cut("ll_mass");
-            if (ll[idilep].p4.M() > m_mll_lowerZcut) manager.pass_cut("ll_mass_lowerZcut");
-        }
-    }
-    const unsigned int nBJets = getNBJets(analyzers);
-    if (nBJets >=2) manager.pass_cut("has_two_bJets"); 
     const HLTProducer& hlt = producers.get<HLTProducer>("hlt");
     for (const std::string& path: hlt.paths) 
     {
@@ -132,7 +90,6 @@ void ElElCategory::evaluate_cuts_post_analyzers(CutManager& manager, const Produ
 bool ElMuCategory::event_in_category_pre_analyzers(const ProducersManager& producers) const {
     const ElectronsProducer& electrons = producers.get<ElectronsProducer>("electrons");
     const MuonsProducer& muons = producers.get<MuonsProducer>("muons");
-    const JetsProducer& alljets = producers.get<JetsProducer>("jets");
     return ((electrons.p4.size() + muons.p4.size()) >= 2);
 };
 
@@ -147,23 +104,10 @@ bool ElMuCategory::event_in_category_post_analyzers(const ProducersManager& prod
 };
 
 void ElMuCategory::register_cuts(CutManager& manager) {
-    manager.new_cut("ll_mass", "mll > 20");
-    manager.new_cut("ll_mass_lowerZcut", "mll > 85");
-    manager.new_cut("has_two_bJets", "nBJet >= 2");
     manager.new_cut("fire_trigger_Mu8_Ele17", "HLT_Mu8_TrkIsoVVL_Ele17_CaloIdL_TrackIdL_IsoVL_*");
 };
 
 void ElMuCategory::evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {
-    const std::vector<HH::Dilepton>& ll = getDileptons(analyzers);
-    for (unsigned int idilep = 0; idilep < ll.size(); idilep++) 
-    {
-        if (ll[idilep].isElMu) {
-            if (ll[idilep].p4.M() > m_mll_cut) manager.pass_cut("ll_mass");
-            if (ll[idilep].p4.M() > m_mll_lowerZcut) manager.pass_cut("ll_mass_lowerZcut");
-        }
-    }
-    const unsigned int nBJets = getNBJets(analyzers);
-    if (nBJets >=2) manager.pass_cut("has_two_bJets"); 
     const HLTProducer& hlt = producers.get<HLTProducer>("hlt");
     for (const std::string& path: hlt.paths) 
     {
@@ -177,7 +121,6 @@ void ElMuCategory::evaluate_cuts_post_analyzers(CutManager& manager, const Produ
 bool MuElCategory::event_in_category_pre_analyzers(const ProducersManager& producers) const {
     const ElectronsProducer& electrons = producers.get<ElectronsProducer>("electrons");
     const MuonsProducer& muons = producers.get<MuonsProducer>("muons");
-    const JetsProducer& alljets = producers.get<JetsProducer>("jets");
     return ((electrons.p4.size() + muons.p4.size()) >= 2);
 };
 
@@ -192,23 +135,10 @@ bool MuElCategory::event_in_category_post_analyzers(const ProducersManager& prod
 };
 
 void MuElCategory::register_cuts(CutManager& manager) {
-    manager.new_cut("ll_mass", "mll > 20");
-    manager.new_cut("ll_mass_lowerZcut", "mll > 85");
-    manager.new_cut("has_two_bJets", "nBJet >= 2");
     manager.new_cut("fire_trigger_Mu17_Ele12", "HLT_Mu17_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_*");
 };
 
 void MuElCategory::evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const {
-    const std::vector<HH::Dilepton>& ll = getDileptons(analyzers);
-    for (unsigned int idilep = 0; idilep < ll.size(); idilep++) 
-    {
-        if (ll[idilep].isMuEl) {
-            if (ll[idilep].p4.M() > m_mll_cut) manager.pass_cut("ll_mass");
-            if (ll[idilep].p4.M() > m_mll_lowerZcut) manager.pass_cut("ll_mass_lowerZcut");
-        }
-    }
-    const unsigned int nBJets = getNBJets(analyzers);
-    if (nBJets >=2) manager.pass_cut("has_two_bJets"); 
     const HLTProducer& hlt = producers.get<HLTProducer>("hlt");
     for (const std::string& path: hlt.paths) 
     {

--- a/plugins/HHAnalyzer.cc
+++ b/plugins/HHAnalyzer.cc
@@ -326,7 +326,6 @@ void HHAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const 
         mymet.gen_DPtOverPt = mymet.gen_matched ? (mymet.p4.Pt() - mymet.gen_p4.Pt()) / mymet.p4.Pt() : -10.;
     }
     met.push_back(mymet);
-    const METProducer& nohf_met = producers.get<METProducer>("nohf_met");  // so that nohfmet is available in the tree
     //const METProducer& puppi_met = producers.get<METProducer>("puppimet");
     // TODO: adding puppi met will require changing the Met AND DileptonMet struct
 

--- a/test/HHConfiguration.py
+++ b/test/HHConfiguration.py
@@ -9,20 +9,15 @@ runOnData = False
 
 if runOnData :
     globalTag = '74X_dataRun2_v2'
-    processName = 'RECO'
 else : 
     globalTag = '74X_mcRun2_asymptotic_v2'
-    processName = None
 
-process = Framework.create(runOnData, eras.Run2_25ns, globalTag, cms.PSet(
+framework = Framework.Framework(runOnData, eras.Run2_25ns, globalTag=globalTag)
 
-    hh_analyzer = cms.PSet(
+framework.addAnalyzer('hh_analyzer', cms.PSet(
         type = cms.string('hh_analyzer'),
         prefix = cms.string('hh_'),
         enable = cms.bool(True),
-        categories_parameters = cms.PSet(
-            mll_cut = cms.untracked.double(10)
-            ),
         parameters = cms.PSet(
             # Here are the default value (just to show what is configurable)
             electronIsoCut_EB_Loose = cms.untracked.double(0.0893), # https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2
@@ -48,26 +43,21 @@ process = Framework.create(runOnData, eras.Run2_25ns, globalTag, cms.PSet(
             minDR_l_j_Cut = cms.untracked.double(0.3),
             hltDRCut = cms.untracked.double(0.3),
             hltDPtCut = cms.untracked.double(0.5)  # cut will be DPt/Pt < hltDPtCut
-            ),
+            )
         )
-    ), 
-    
-    redoJEC=False,
-    process_name=processName
+    ) 
 
-    )
+#framework.redoJEC()
+#framework.smearJets()
+framework.doSystematics(['jec']) #, 'jer'])
 
-# Add PUPPI MET
-process.framework.producers.puppimet = cms.PSet(METProducer.default_configuration.clone())
-process.framework.producers.puppimet.prefix = cms.string('puppimet_')
-process.framework.producers.puppimet.parameters.met = cms.untracked.InputTag('slimmedMETsPuppi')
+process = framework.create()
 
-# Custom the cuts
-process.framework.producers.jets.parameters.cut = cms.untracked.string("pt > 20")
-#process.framework.producers.muons.parameters.cut = cms.untracked.string("pt > 20")
-#process.framework.producers.electrons.parameters.cut = cms.untracked.string("pt > 20")
 
-Framework.schedule(process, ['hh_analyzer'])
+## Add PUPPI MET
+#process.framework.producers.puppimet = cms.PSet(METProducer.default_configuration.clone())
+#process.framework.producers.puppimet.prefix = cms.string('puppimet_')
+#process.framework.producers.puppimet.parameters.met = cms.untracked.InputTag('slimmedMETsPuppi')
 
 if runOnData : 
     process.source.fileNames = cms.untracked.vstring(


### PR DESCRIPTION
We discussed the fact to suppress the nJet > 2 pre analyzer cut few weeks  ago. This cut does not save a lot of time/size and makes the cut flow messy. The only way to produce the yields cut by cut later on would be to add lepton counter in the Analyzer but we would need one lepton counter per lepton ID, iso,  etc. I think it is cleaner and easier to simply remove it.
