### PR TITLE
Compute mHH & cos(theta)* at gen level

### DIFF
--- a/interface/HHAnalyzer.h
+++ b/interface/HHAnalyzer.h
@@ -162,6 +162,14 @@ class HHAnalyzer: public Framework::Analyzer {
 
         BRANCH(gen_ttbar_decay_type, char); // Type of ttbar decay. Can take any values from TTDecayType enum
 
+        // Di-higgs gen system
+        BRANCH(gen_iH1, char);
+        BRANCH(gen_iH2, char);
+        BRANCH(gen_H1, LorentzVector);
+        BRANCH(gen_H2, LorentzVector);
+        BRANCH(gen_mHH, double);
+        BRANCH(gen_costhetastar, double);
+
     private:
         // Producers name
         std::string m_electrons_producer;


### PR DESCRIPTION
This is a quick fix if we want to launch on signal tomorrow.

P4 of the two Higgs from the hard process are stored in the tree, as well as mHH and cos(theta)*. I used the flag `isHardProcess` as it's the only only which is set for the higgs in the gen history, and it's always the two first higgs in the history. Other higgs have only the flag `fromHardProcess` set, but none have the previously used `isLastCopyBeforeFSR` flag set...

It's anyway coherent with what is done to extract the weights for the v1 to v3 reweighting.
