### PR TITLE
Improvements and stuff

### DIFF
--- a/interface/HHAnalyzer.h
+++ b/interface/HHAnalyzer.h
@@ -73,21 +73,13 @@ class HHAnalyzer: public Framework::Analyzer {
         std::vector<HH::DileptonMet> llmet;
         std::vector<HH::Dijet> jj;
         std::vector<HH::DileptonMetDijet> llmetjj;
+        std::vector<HH::DileptonMetDijet> llmetjj_csv;
         // some few custom candidates, for convenience
         // Januray 2016: preapproval freezing custom candidates
         BRANCH(llmetjj_HWWleptons_nobtag_csv, std::vector<HH::DileptonMetDijet>);
         BRANCH(llmetjj_HWWleptons_btagL_csv, std::vector<HH::DileptonMetDijet>);
         BRANCH(llmetjj_HWWleptons_btagM_csv, std::vector<HH::DileptonMetDijet>);
         BRANCH(llmetjj_HWWleptons_btagT_csv, std::vector<HH::DileptonMetDijet>);
-
-        // maps
-        std::vector<std::vector<int>> map_l = std::vector<std::vector<int>>(lepID::Count * lepIso::Count, std::vector<int>(0));
-        std::vector<std::vector<int>> map_ll = std::vector<std::vector<int>>(lepID::Count * lepIso::Count * lepID::Count * lepIso::Count, std::vector<int>(0));
-        // FIXME: add enum over met?
-        std::vector<std::vector<int>> map_llmet = std::vector<std::vector<int>>(lepID::Count * lepIso::Count * lepID::Count * lepIso::Count, std::vector<int>(0));
-        std::vector<std::vector<int>> map_j = std::vector<std::vector<int>>(jetID::Count * btagWP::Count, std::vector<int>(0));
-        std::vector<std::vector<int>> map_jj = std::vector<std::vector<int>>(jetID::Count * jetID::Count * btagWP::Count * btagWP::Count * jetPair::Count, std::vector<int>(0));
-        std::vector<std::vector<int>> map_llmetjj = std::vector<std::vector<int>>(lepID::Count * lepIso::Count * lepID::Count * lepIso::Count * jetID::Count * jetID::Count * btagWP::Count * btagWP::Count * jetPair::Count, std::vector<int>(0));
 
         virtual void analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager&, const AnalyzersManager&, const CategoryManager&) override;
         virtual void registerCategories(CategoryManager& manager, const edm::ParameterSet& config) override;

--- a/interface/HHAnalyzer.h
+++ b/interface/HHAnalyzer.h
@@ -85,6 +85,7 @@ class HHAnalyzer: public Framework::Analyzer {
         virtual void registerCategories(CategoryManager& manager, const edm::ParameterSet& config) override;
 
         float getCosThetaStar_CS(const LorentzVector & h1, const LorentzVector & h2, float ebeam = 6500);
+        MELAAngles getMELAAngles(const LorentzVector &q1, const LorentzVector &q2, const LorentzVector &q11, const LorentzVector &q12, const LorentzVector &q21, const LorentzVector &q22, float ebeam = 6500);
 
         void fillTriggerEfficiencies(const Lepton & lep1, const Lepton & lep2, Dilepton & dilep);
 

--- a/interface/HHAnalyzer.h
+++ b/interface/HHAnalyzer.h
@@ -80,6 +80,9 @@ class HHAnalyzer: public Framework::Analyzer {
         BRANCH(llmetjj_HWWleptons_btagL_csv, std::vector<HH::DileptonMetDijet>);
         BRANCH(llmetjj_HWWleptons_btagM_csv, std::vector<HH::DileptonMetDijet>);
         BRANCH(llmetjj_HWWleptons_btagT_csv, std::vector<HH::DileptonMetDijet>);
+        // October 2016: adding some asymmetric btag candidates, for study
+        BRANCH(llmetjj_HWWleptons_btagLM_csv, std::vector<HH::DileptonMetDijet>);
+        BRANCH(llmetjj_HWWleptons_btagMT_csv, std::vector<HH::DileptonMetDijet>);
 
         virtual void analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager&, const AnalyzersManager&, const CategoryManager&) override;
         virtual void registerCategories(CategoryManager& manager, const edm::ParameterSet& config) override;

--- a/interface/Tools.h
+++ b/interface/Tools.h
@@ -1,0 +1,237 @@
+#pragma once
+
+#include <cp3_llbb/HHAnalysis/interface/HHAnalyzer.h>
+#include <cp3_llbb/HHAnalysis/interface/Types.h>
+#include <Math/Vector3D.h>
+
+float HHAnalyzer::getCosThetaStar_CS(const LorentzVector & h1, const LorentzVector & h2, float ebeam /*= 6500*/) {
+// cos theta star angle in the Collins Soper frame
+    LorentzVector p1, p2;
+    p1.SetPxPyPzE(0, 0,  ebeam, ebeam);
+    p2.SetPxPyPzE(0, 0, -ebeam, ebeam);
+
+    LorentzVector hh = h1 + h2;
+    ROOT::Math::Boost boost(-hh.X() / hh.T(), -hh.Y() / hh.T(), -hh.Z() / hh.T());
+    p1 = boost(p1);
+    p2 = boost(p2);
+    LorentzVector newh1 = boost(h1);
+    ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<float>> CSaxis(p1.Vect().Unit() - p2.Vect().Unit());
+
+    return cos(ROOT::Math::VectorUtil::Angle(CSaxis.Unit(), newh1.Vect().Unit()));
+}
+
+MELAAngles HHAnalyzer::getMELAAngles(const LorentzVector &q1, const LorentzVector &q2, const LorentzVector &q11, const LorentzVector &q12, const LorentzVector &q21, const LorentzVector &q22, float ebeam /*= 6500*/) {
+    MELAAngles angles;
+    LorentzVector p1, p2;
+    p1.SetPxPyPzE(0, 0,  ebeam, ebeam);
+    p2.SetPxPyPzE(0, 0, -ebeam, ebeam);
+
+    // set yourselves to the q1 + q2 rest frame, everyone! (note the prefix 'b' for 'boosted')
+    LorentzVector X = q1 + q2;
+    ROOT::Math::Boost boost(-X.X() / X.T(), -X.Y() / X.T(), -X.Z() / X.T());
+    LorentzVector b_p1 = boost(p1);
+    LorentzVector b_p2 = boost(p2);
+    LorentzVector b_q1 = boost(q1);
+    LorentzVector b_q11 = boost(q11);
+    LorentzVector b_q12 = boost(q12);
+    LorentzVector b_q21 = boost(q21);
+    LorentzVector b_q22 = boost(q22);
+    // Amend that, actually we also want some stuff in q1 or q2 rest frame
+    ROOT::Math::Boost boost1(-q1.X() / q1.T(), -q1.Y() / q1.T(), -q1.Z() / q1.T());
+    ROOT::Math::Boost boost2(-q2.X() / q2.T(), -q2.Y() / q2.T(), -q2.Z() / q2.T());
+    LorentzVector b1_q2 = boost1(q2);
+    LorentzVector b1_q11 = boost1(q11);
+    LorentzVector b2_q1 = boost2(q1);
+    LorentzVector b2_q21 = boost2(q21);
+    // let's concentrate on three-momenta (note the prefix 'm' for three-'momenta')
+    ROOT::Math::XYZVectorF m_q1(b_q1.Px(), b_q1.Py(), b_q1.Pz());
+    ROOT::Math::XYZVectorF m_q11(b_q11.Px(), b_q11.Py(), b_q11.Pz());
+    ROOT::Math::XYZVectorF m_q12(b_q12.Px(), b_q12.Py(), b_q12.Pz());
+    ROOT::Math::XYZVectorF m_q21(b_q21.Px(), b_q21.Py(), b_q21.Pz());
+    ROOT::Math::XYZVectorF m_q22(b_q22.Px(), b_q22.Py(), b_q22.Pz());
+    // let's get as well three-momenta in q1 and q2 rest frame where appropriate;
+    ROOT::Math::XYZVectorF m1_q2(b1_q2.Px(), b1_q2.Py(), b1_q2.Pz());
+    ROOT::Math::XYZVectorF m1_q11(b1_q11.Px(), b1_q11.Py(), b1_q11.Pz());
+    ROOT::Math::XYZVectorF m2_q1(b2_q1.Px(), b2_q1.Py(), b2_q1.Pz());
+    ROOT::Math::XYZVectorF m2_q21(b2_q21.Px(), b2_q21.Py(), b2_q21.Pz());
+
+    // Define reference vectors
+    ROOT::Math::XYZVectorF n1(m_q11.Cross(m_q12).Unit());
+    ROOT::Math::XYZVectorF n2(m_q21.Cross(m_q22).Unit());
+    ROOT::Math::XYZVectorF nz(0., 0., 1.);
+    ROOT::Math::XYZVectorF nsc(nz.Cross(m_q1).Unit());
+
+    // MELA angles as taken from https://arxiv.org/pdf/1208.4018v3.pdf
+    angles.phi = m_q1.Dot(n1.Cross(n2)) / fabs(m_q1.Dot(n1.Cross(n2))) * acos(- n1.Dot(n2));
+    float phi1 = m_q1.Dot(n1.Cross(nsc)) / fabs(m_q1.Dot(n1.Cross(nsc))) * acos(n1.Dot(nsc));
+    angles.psi = phi1 + angles.phi / 2.;
+    angles.theta1 = acos(- m1_q2.Dot(m1_q11) / sqrt(m1_q2.Dot(m1_q2)) / sqrt(m1_q11.Dot(m1_q11)));
+    angles.theta2 = acos(- m2_q1.Dot(m2_q21) / sqrt(m2_q1.Dot(m2_q1)) / sqrt(m2_q21.Dot(m2_q21)));
+    // thetaStar is defined in the Collins-Soper frame
+    ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<float>> CSaxis(b_p1.Vect().Unit() - b_p2.Vect().Unit());
+    angles.thetaStar = ROOT::Math::VectorUtil::Angle(CSaxis.Unit(), b_q1.Vect().Unit());
+
+    return angles;
+}
+
+void HHAnalyzer::fillTriggerEfficiencies(const Lepton & lep1, const Lepton & lep2, Dilepton & dilep) {
+
+    float eff_lep1_leg1 = 1.;
+    float eff_lep1_leg2 = 1.;
+    float eff_lep1_tkleg2 = 0.;
+    float eff_lep2_leg1 = 1.;
+    float eff_lep2_leg2 = 1.;
+    float eff_lep2_tkleg2 = 0.;
+    Parameters p_hlt_lep1 = {{BinningVariable::Eta, lep1.p4.Eta()}, {BinningVariable::Pt, lep1.p4.Pt()}};
+    Parameters p_hlt_lep2 = {{BinningVariable::Eta, lep2.p4.Eta()}, {BinningVariable::Pt, lep2.p4.Pt()}};
+
+    if (lep1.isMu && lep2.isMu) {
+        eff_lep1_leg1 = m_hlt_efficiencies["DoubleIsoMu17Mu8_IsoMu17leg"].get(p_hlt_lep1)[0];
+        eff_lep1_leg2 = m_hlt_efficiencies["DoubleIsoMu17Mu8_IsoMu8orIsoTkMu8leg"].get(p_hlt_lep1)[0];
+        //eff_lep1_tkleg2 = m_hlt_efficiencies["DoubleIsoMu17Mu8_TkMu8leg"].get(p_hlt_lep1)[0];
+        eff_lep2_leg1 = m_hlt_efficiencies["DoubleIsoMu17Mu8_IsoMu17leg"].get(p_hlt_lep2)[0];
+        eff_lep2_leg2 = m_hlt_efficiencies["DoubleIsoMu17Mu8_IsoMu8orIsoTkMu8leg"].get(p_hlt_lep2)[0];
+        //eff_lep2_tkleg2 = m_hlt_efficiencies["DoubleIsoMu17Mu8_TkMu8leg"].get(p_hlt_lep2)[0];
+    }
+    else if (lep1.isMu && lep2.isEl) {
+        eff_lep1_leg1 = m_hlt_efficiencies["DoubleIsoMu17Mu8_IsoMu17leg"].get(p_hlt_lep1)[0];
+        eff_lep1_leg2 = m_hlt_efficiencies["DoubleIsoMu17Mu8_IsoMu8leg"].get(p_hlt_lep1)[0];
+        eff_lep2_leg1 = m_hlt_efficiencies["Ele17_12Leg1"].get(p_hlt_lep2)[0];
+        eff_lep2_leg2 = m_hlt_efficiencies["Ele17_12Leg2"].get(p_hlt_lep2)[0];
+    }
+    else if (lep1.isEl && lep2.isMu) {
+        eff_lep1_leg1 = m_hlt_efficiencies["Ele17_12Leg1"].get(p_hlt_lep1)[0];
+        eff_lep1_leg2 = m_hlt_efficiencies["Ele17_12Leg2"].get(p_hlt_lep1)[0];
+        eff_lep2_leg1 = m_hlt_efficiencies["DoubleIsoMu17Mu8_IsoMu17leg"].get(p_hlt_lep2)[0];
+        eff_lep2_leg2 = m_hlt_efficiencies["DoubleIsoMu17Mu8_IsoMu8leg"].get(p_hlt_lep2)[0];
+    }
+    else if (lep1.isEl && lep2.isEl){
+        eff_lep1_leg1 = m_hlt_efficiencies["Ele17_12Leg1"].get(p_hlt_lep1)[0];
+        eff_lep1_leg2 = m_hlt_efficiencies["Ele17_12Leg2"].get(p_hlt_lep1)[0];
+        eff_lep2_leg1 = m_hlt_efficiencies["Ele17_12Leg1"].get(p_hlt_lep2)[0];
+        eff_lep2_leg2 = m_hlt_efficiencies["Ele17_12Leg2"].get(p_hlt_lep2)[0];
+    }
+    else 
+        std::cout << "We have something else then el or mu !!" << std::endl;
+
+    float error_eff_lep1_leg1_up = 0.;
+    float error_eff_lep1_leg2_up = 0.;
+    float error_eff_lep1_tkleg2_up = 0.;
+    float error_eff_lep2_leg1_up = 0.;
+    float error_eff_lep2_leg2_up = 0.;
+    float error_eff_lep2_tkleg2_up = 0.;
+
+    if (lep1.isMu && lep2.isMu) {
+        error_eff_lep1_leg1_up = m_hlt_efficiencies["DoubleIsoMu17Mu8_IsoMu17leg"].get(p_hlt_lep1)[2];
+        error_eff_lep1_leg2_up = m_hlt_efficiencies["DoubleIsoMu17Mu8_IsoMu8orIsoTkMu8leg"].get(p_hlt_lep1)[2];
+        //error_eff_lep1_tkleg2_up = m_hlt_efficiencies["DoubleIsoMu17Mu8_TkMu8leg"].get(p_hlt_lep1)[2];
+        error_eff_lep2_leg1_up = m_hlt_efficiencies["DoubleIsoMu17Mu8_IsoMu17leg"].get(p_hlt_lep2)[2];
+        error_eff_lep2_leg2_up = m_hlt_efficiencies["DoubleIsoMu17Mu8_IsoMu8orIsoTkMu8leg"].get(p_hlt_lep2)[2];
+        //error_eff_lep2_tkleg2_up = m_hlt_efficiencies["DoubleIsoMu17Mu8_TkMu8leg"].get(p_hlt_lep2)[2];
+    }
+    else if (lep1.isMu && lep2.isEl) {
+        error_eff_lep1_leg1_up = m_hlt_efficiencies["DoubleIsoMu17Mu8_IsoMu17leg"].get(p_hlt_lep1)[2];
+        error_eff_lep1_leg2_up = m_hlt_efficiencies["DoubleIsoMu17Mu8_IsoMu8leg"].get(p_hlt_lep1)[2];
+        error_eff_lep2_leg1_up = m_hlt_efficiencies["Ele17_12Leg1"].get(p_hlt_lep2)[2];
+        error_eff_lep2_leg2_up = m_hlt_efficiencies["Ele17_12Leg2"].get(p_hlt_lep2)[2];
+    }
+    else if (lep1.isEl && lep2.isMu) {
+        error_eff_lep1_leg1_up = m_hlt_efficiencies["Ele17_12Leg1"].get(p_hlt_lep1)[2];
+        error_eff_lep1_leg2_up = m_hlt_efficiencies["Ele17_12Leg2"].get(p_hlt_lep1)[2];
+        error_eff_lep2_leg1_up = m_hlt_efficiencies["DoubleIsoMu17Mu8_IsoMu17leg"].get(p_hlt_lep2)[2];
+        error_eff_lep2_leg2_up = m_hlt_efficiencies["DoubleIsoMu17Mu8_IsoMu8leg"].get(p_hlt_lep2)[2];
+    }
+    else if (lep1.isEl && lep2.isEl){
+        error_eff_lep1_leg1_up = m_hlt_efficiencies["Ele17_12Leg1"].get(p_hlt_lep1)[2];
+        error_eff_lep1_leg2_up = m_hlt_efficiencies["Ele17_12Leg2"].get(p_hlt_lep1)[2];
+        error_eff_lep2_leg1_up = m_hlt_efficiencies["Ele17_12Leg1"].get(p_hlt_lep2)[2];
+        error_eff_lep2_leg2_up = m_hlt_efficiencies["Ele17_12Leg2"].get(p_hlt_lep2)[2];
+    }
+
+    float error_eff_lep1_leg1_down = 0.;
+    float error_eff_lep1_leg2_down = 0.;
+    float error_eff_lep1_tkleg2_down = 0.;
+    float error_eff_lep2_leg1_down = 0.;
+    float error_eff_lep2_leg2_down = 0.;
+    float error_eff_lep2_tkleg2_down = 0.;
+
+    if (lep1.isMu && lep2.isMu) {
+        error_eff_lep1_leg1_down = m_hlt_efficiencies["DoubleIsoMu17Mu8_IsoMu17leg"].get(p_hlt_lep1)[1];
+        error_eff_lep1_leg2_down = m_hlt_efficiencies["DoubleIsoMu17Mu8_IsoMu8orIsoTkMu8leg"].get(p_hlt_lep1)[1];
+        //error_eff_lep1_tkleg2_down = m_hlt_efficiencies["DoubleIsoMu17Mu8_TkMu8leg"].get(p_hlt_lep1)[1];
+        error_eff_lep2_leg1_down = m_hlt_efficiencies["DoubleIsoMu17Mu8_IsoMu17leg"].get(p_hlt_lep2)[1];
+        error_eff_lep2_leg2_down = m_hlt_efficiencies["DoubleIsoMu17Mu8_IsoMu8orIsoTkMu8leg"].get(p_hlt_lep2)[1];
+        //error_eff_lep2_tkleg2_down = m_hlt_efficiencies["DoubleIsoMu17Mu8_TkMu8leg"].get(p_hlt_lep2)[1];
+    }
+    else if (lep1.isMu && lep2.isEl) {
+        error_eff_lep1_leg1_down = m_hlt_efficiencies["DoubleIsoMu17Mu8_IsoMu17leg"].get(p_hlt_lep1)[1];
+        error_eff_lep1_leg2_down = m_hlt_efficiencies["DoubleIsoMu17Mu8_IsoMu8leg"].get(p_hlt_lep1)[1];
+        error_eff_lep2_leg1_down = m_hlt_efficiencies["Ele17_12Leg1"].get(p_hlt_lep2)[1];
+        error_eff_lep2_leg2_down = m_hlt_efficiencies["Ele17_12Leg2"].get(p_hlt_lep2)[1];
+    }
+    else if (lep1.isEl && lep2.isMu) {
+        error_eff_lep1_leg1_down = m_hlt_efficiencies["Ele17_12Leg1"].get(p_hlt_lep1)[1];
+        error_eff_lep1_leg2_down = m_hlt_efficiencies["Ele17_12Leg2"].get(p_hlt_lep1)[1];
+        error_eff_lep2_leg1_down = m_hlt_efficiencies["DoubleIsoMu17Mu8_IsoMu17leg"].get(p_hlt_lep2)[1];
+        error_eff_lep2_leg2_down = m_hlt_efficiencies["DoubleIsoMu17Mu8_IsoMu8leg"].get(p_hlt_lep2)[1];
+    }
+    else if (lep1.isEl && lep2.isEl){
+        error_eff_lep1_leg1_down = m_hlt_efficiencies["Ele17_12Leg1"].get(p_hlt_lep1)[1];
+        error_eff_lep1_leg2_down = m_hlt_efficiencies["Ele17_12Leg2"].get(p_hlt_lep1)[1];
+        error_eff_lep2_leg1_down = m_hlt_efficiencies["Ele17_12Leg1"].get(p_hlt_lep2)[1];
+        error_eff_lep2_leg2_down = m_hlt_efficiencies["Ele17_12Leg2"].get(p_hlt_lep2)[1];
+    }
+
+
+    float nominal = -(eff_lep1_leg1 * eff_lep2_leg1) +
+        (1 - (1 - eff_lep1_leg2) * (1 - eff_lep1_tkleg2)) * eff_lep2_leg1 +
+        eff_lep1_leg1 * (1 - (1 - eff_lep2_leg2) * (1 - eff_lep2_tkleg2));
+
+    float error_squared_up =
+        std::pow(1 - eff_lep2_leg1 - (1 - eff_lep2_leg2) * (1 - eff_lep2_tkleg2), 2) *
+        std::pow(error_eff_lep1_leg1_up, 2) +
+        std::pow(1 - eff_lep1_tkleg2, 2) * std::pow(eff_lep2_leg1, 2) *
+        std::pow(error_eff_lep1_leg2_up, 2) +
+        std::pow(1 - eff_lep1_leg2, 2) * std::pow(eff_lep2_leg1, 2) *
+        std::pow(error_eff_lep1_tkleg2_up, 2) +
+        std::pow(1 - eff_lep1_leg1 - (1 - eff_lep1_leg2) * (1 - eff_lep1_tkleg2), 2) *
+        std::pow(error_eff_lep2_leg1_up, 2) +
+        std::pow(eff_lep1_leg1, 2) * std::pow(1 - eff_lep2_tkleg2, 2) *
+        std::pow(error_eff_lep2_leg2_up, 2) +
+        std::pow(eff_lep1_leg1, 2) * std::pow(1 - eff_lep2_leg2, 2) *
+        std::pow(error_eff_lep2_tkleg2_up, 2);
+
+    float error_squared_down = 
+        std::pow(1 - eff_lep2_leg1 - (1 - eff_lep2_leg2) * (1 - eff_lep2_tkleg2), 2) *
+        std::pow(error_eff_lep1_leg1_down, 2) +
+        std::pow(1 - eff_lep1_tkleg2, 2) * std::pow(eff_lep2_leg1, 2) *
+        std::pow(error_eff_lep1_leg2_down, 2) +
+        std::pow(1 - eff_lep1_leg2, 2) * std::pow(eff_lep2_leg1, 2) *
+        std::pow(error_eff_lep1_tkleg2_down, 2) +
+        std::pow(1 - eff_lep1_leg1 - (1 - eff_lep1_leg2) * (1 - eff_lep1_tkleg2), 2) *
+        std::pow(error_eff_lep2_leg1_down, 2) +
+        std::pow(eff_lep1_leg1, 2) * std::pow(1 - eff_lep2_tkleg2, 2) *
+        std::pow(error_eff_lep2_leg2_down, 2) +
+        std::pow(eff_lep1_leg1, 2) * std::pow(1 - eff_lep2_leg2, 2) *
+        std::pow(error_eff_lep2_tkleg2_down, 2);
+
+    dilep.trigger_efficiency = nominal;
+    dilep.trigger_efficiency_upVariated = ((nominal + std::sqrt(error_squared_up)) > 1.)? 1. : nominal + std::sqrt(error_squared_up);
+    dilep.trigger_efficiency_downVariated = ((nominal - std::sqrt(error_squared_down)) < 0.)? 0. : nominal - std::sqrt(error_squared_down);
+    
+    // Arun's method (not using the proper derivative formula)
+    float X = eff_lep1_leg1 * eff_lep2_leg2 * std::sqrt((std::pow((error_eff_lep1_leg1_up/eff_lep1_leg1),2) + std::pow((error_eff_lep2_leg2_up/eff_lep2_leg2),2) ));
+    float Y = eff_lep2_leg1 * eff_lep1_leg2 * std::sqrt((std::pow((error_eff_lep2_leg1_up/eff_lep2_leg1),2) + std::pow((error_eff_lep1_leg2_up/eff_lep1_leg2),2) ));
+    float Z = eff_lep1_leg1 * eff_lep2_leg1 * std::sqrt((std::pow((error_eff_lep1_leg1_up/eff_lep1_leg1),2) + std::pow((error_eff_lep2_leg1_up/eff_lep2_leg1),2) ));
+    float error_squared_up_Arun = X*X + Y*Y + Z*Z ;
+    dilep.trigger_efficiency_upVariated_Arun = ((nominal + std::sqrt(error_squared_up_Arun)) > 1.)? 1. : nominal + std::sqrt(error_squared_up_Arun);
+
+    X = eff_lep1_leg1 * eff_lep2_leg2 * std::sqrt((std::pow((error_eff_lep1_leg1_down/eff_lep1_leg1),2) + std::pow((error_eff_lep2_leg2_down/eff_lep2_leg2),2) ));
+    Y = eff_lep2_leg1 * eff_lep1_leg2 * std::sqrt((std::pow((error_eff_lep2_leg1_down/eff_lep2_leg1),2) + std::pow((error_eff_lep1_leg2_down/eff_lep1_leg2),2) ));
+    Z = eff_lep1_leg1 * eff_lep2_leg1 * std::sqrt((std::pow((error_eff_lep1_leg1_down/eff_lep1_leg1),2) + std::pow((error_eff_lep2_leg1_down/eff_lep2_leg1),2) ));
+    float error_squared_down_Arun = X*X + Y*Y + Z*Z ;
+    dilep.trigger_efficiency_downVariated_Arun = ((nominal - std::sqrt(error_squared_down_Arun)) < 0.)? 0. : nominal - std::sqrt(error_squared_down_Arun);
+
+}
+
+

--- a/interface/Types.h
+++ b/interface/Types.h
@@ -38,6 +38,8 @@ namespace HH {
         int ilep2; // index in the HH::Lepton collection
         std::pair<int8_t, int8_t> hlt_idxs = std::make_pair(-1,-1); // Stores indices of matched online objects. (-1,-1) if no match
         bool isOS; // Opposite Sign
+        bool isPlusMinus;
+        bool isMinusPlus;
         bool isMuMu;
         bool isElEl;
         bool isElMu;

--- a/interface/Types.h
+++ b/interface/Types.h
@@ -72,6 +72,7 @@ namespace HH {
         bool iso_HWWHWW;
         float DR_l_l;
         float DPhi_l_l;
+        float ht_l_l;
         bool gen_matched;
         float gen_DR;
         float gen_DPtOverPt;
@@ -149,6 +150,7 @@ namespace HH {
         float sumJP;
         float DR_j_j;
         float DPhi_j_j;
+        float ht_j_j;
         bool gen_matched_bbPartons;
         bool gen_matched_bbHadrons;
         bool gen_matched;

--- a/interface/Types.h
+++ b/interface/Types.h
@@ -131,6 +131,9 @@ namespace HH {
         std::pair<int, int> idxs; // indices in the framework collection
         int ijet1; // indices in the HH::Jet collection
         int ijet2;
+        bool jid_LL;
+        bool jid_TT;
+        bool jid_TLVTLV;
         bool btag_LL;
         bool btag_LM;
         bool btag_LT;

--- a/interface/Types.h
+++ b/interface/Types.h
@@ -156,6 +156,13 @@ namespace HH {
         bool gen_cl;
         bool gen_ll;
     };
+    struct MELAAngles {
+        float theta1;
+        float theta2;
+        float thetaStar; // same angle as cosThetaStar_CS
+        float phi;
+        float psi;
+    };
     struct DileptonMetDijet : public DileptonMet, public Dijet {
         LorentzVector p4;
         LorentzVector lep1_p4;
@@ -192,6 +199,8 @@ namespace HH {
         float gen_DR;
         float gen_DPhi;
         float gen_DPtOverPt;
+        MELAAngles melaAngles;
+        MELAAngles visMelaAngles;
     };
 }
 

--- a/plugins/HHAnalyzer.cc
+++ b/plugins/HHAnalyzer.cc
@@ -171,6 +171,8 @@ void HHAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const 
             dilep.ilep1 = ilep1;
             dilep.ilep2 = ilep2;
             dilep.isOS = leptons[ilep1].charge * leptons[ilep2].charge < 0;
+            dilep.isPlusMinus = leptons[ilep1].charge > 0 && leptons[ilep2].charge < 0;
+            dilep.isMinusPlus = leptons[ilep1].charge < 0 && leptons[ilep2].charge > 0;
             dilep.isMuMu = leptons[ilep1].isMu && leptons[ilep2].isMu;
             dilep.isElEl = leptons[ilep1].isEl && leptons[ilep2].isEl;
             dilep.isElMu = leptons[ilep1].isEl && leptons[ilep2].isMu;
@@ -290,6 +292,8 @@ void HHAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const 
             myllmet.ilep1 = ll[ill].ilep1;
             myllmet.ilep2 = ll[ill].ilep2;
             myllmet.isOS = ll[ill].isOS;
+            myllmet.isPlusMinus = ll[ill].isPlusMinus;
+            myllmet.isMinusPlus = ll[ill].isMinusPlus;
             myllmet.isMuMu = ll[ill].isMuMu;
             myllmet.isElEl = ll[ill].isElEl;
             myllmet.isElMu = ll[ill].isElMu;
@@ -504,6 +508,8 @@ void HHAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const 
             myllmetjj.ilep1 = ll[ill].ilep1;
             myllmetjj.ilep2 = ll[ill].ilep2;
             myllmetjj.isOS = ll[ill].isOS;
+            myllmetjj.isPlusMinus = ll[ill].isPlusMinus;
+            myllmetjj.isMinusPlus = ll[ill].isMinusPlus;
             myllmetjj.isMuMu = ll[ill].isMuMu;
             myllmetjj.isElEl = ll[ill].isElEl;
             myllmetjj.isElMu = ll[ill].isElMu;

--- a/plugins/HHAnalyzer.cc
+++ b/plugins/HHAnalyzer.cc
@@ -401,6 +401,9 @@ void HHAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const 
             myjj.idxs = std::make_pair(jets[ijet1].idx, jets[ijet2].idx);
             myjj.ijet1 = ijet1;
             myjj.ijet2 = ijet2;
+            myjj.jid_LL = jets[ijet1].id_L && jets[ijet2].id_L;
+            myjj.jid_TT = jets[ijet1].id_T && jets[ijet2].id_T;
+            myjj.jid_TLVTLV = jets[ijet1].id_TLV && jets[ijet2].id_TLV;
             myjj.btag_LL = jets[ijet1].btag_L && jets[ijet2].btag_L;
             myjj.btag_LM = (jets[ijet1].btag_L && jets[ijet2].btag_M) || (jets[ijet2].btag_L && jets[ijet1].btag_M);
             myjj.btag_LT = (jets[ijet1].btag_L && jets[ijet2].btag_T) || (jets[ijet2].btag_L && jets[ijet1].btag_T);
@@ -473,6 +476,9 @@ void HHAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const 
             // blind copy of the jj content
             myllmetjj.ijet1 = jj[ijj].ijet1;
             myllmetjj.ijet2 = jj[ijj].ijet2;
+            myllmetjj.jid_LL = jj[ijj].jid_LL;
+            myllmetjj.jid_TT = jj[ijj].jid_TT;
+            myllmetjj.jid_TLVTLV = jj[ijj].jid_TLVTLV;
             myllmetjj.btag_LL = jj[ijj].btag_LL;
             myllmetjj.btag_LM = jj[ijj].btag_LM;
             myllmetjj.btag_LT = jj[ijj].btag_LT;

--- a/plugins/HHAnalyzer.cc
+++ b/plugins/HHAnalyzer.cc
@@ -238,6 +238,8 @@ void HHAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const 
             ll.push_back(dilep); 
         }
     }
+    // have the ll collection sorted by ht
+    std::sort(ll.begin(), ll.end(), [&](HH::Dijet& a, HH::Dijet& b){return a.p4.Pt() > b.p4.Pt();});
 
     // ***** 
     // Adding MET(s)
@@ -389,7 +391,6 @@ void HHAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const 
 
     jj.clear();
     // Do NOT change the loop logic here: we expect [0] to be made out of the leading jets
-
     for (unsigned int ijet1 = 0; ijet1 < jets.size(); ijet1++)
     {
         for (unsigned int ijet2 = ijet1 + 1; ijet2 < jets.size(); ijet2++)
@@ -427,6 +428,8 @@ void HHAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const 
             jj.push_back(myjj);
         }
     }
+    // have the jj collection sorted by ht
+    std::sort(jj.begin(), jj.end(), [&](HH::Dijet& a, HH::Dijet& b){return a.p4.Pt() > b.p4.Pt();});
 
     // ********** 
     // lljj, llbb, +pf_met

--- a/plugins/HHAnalyzer.cc
+++ b/plugins/HHAnalyzer.cc
@@ -624,6 +624,11 @@ void HHAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const 
             llmetjj_HWWleptons_btagM_csv.push_back(myllmetjj_csv);
         if (myllmetjj_csv.btag_TT)
             llmetjj_HWWleptons_btagT_csv.push_back(myllmetjj_csv);
+        // October 2016: asymmetric btag candidates
+        if (myllmetjj_csv.btag_LM || myllmetjj_csv.btag_ML)
+            llmetjj_HWWleptons_btagLM_csv.push_back(myllmetjj_csv);
+        if (myllmetjj_csv.btag_MT || myllmetjj_csv.btag_TM)
+            llmetjj_HWWleptons_btagMT_csv.push_back(myllmetjj_csv);
     }
 
 

--- a/plugins/HHAnalyzer.cc
+++ b/plugins/HHAnalyzer.cc
@@ -30,7 +30,7 @@ void HHAnalyzer::registerCategories(CategoryManager& manager, const edm::Paramet
 
 void HHAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const ProducersManager& producers, const AnalyzersManager&, const CategoryManager&) {
 
-    float mh = event.isRealData() ? 125.02 : 125.0;
+    //float mh = event.isRealData() ? 125.09 : 125.0;
     LorentzVector null_p4(0., 0., 0., 0.);
     const EventProducer& fwevent = producers.get<EventProducer>("event");
     float event_weight = fwevent.weight;
@@ -158,54 +158,6 @@ void HHAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const 
     // sort leptons by pt (ignoring flavour, id and iso)
     std::sort(leptons.begin(), leptons.end(), [](const HH::Lepton& lep1, const HH::Lepton& lep2) { return lep1.p4.Pt() > lep2.p4.Pt(); });     
 
-    // Fill lepton maps
-    for (unsigned int i_id_iso = 0; i_id_iso < map_l.size(); i_id_iso++)
-        map_l[i_id_iso].clear();
-
-    for (unsigned int ilepton = 0; ilepton < leptons.size(); ilepton++)
-    {
-        if (leptons[ilepton].id_L)
-        {
-            map_l[ lepIDIso(lepID::L, lepIso::no) ].push_back(ilepton);
-            if (leptons[ilepton].iso_L)
-                map_l[ lepIDIso(lepID::L, lepIso::L) ].push_back(ilepton);
-            if (leptons[ilepton].iso_T)
-                map_l[ lepIDIso(lepID::L, lepIso::T) ].push_back(ilepton);
-            if (leptons[ilepton].iso_HWW)
-                map_l[ lepIDIso(lepID::L, lepIso::HWW) ].push_back(ilepton);
-        }
-        if (leptons[ilepton].id_M)
-        {
-            map_l[ lepIDIso(lepID::M, lepIso::no) ].push_back(ilepton);
-            if (leptons[ilepton].iso_L)
-                map_l[ lepIDIso(lepID::M, lepIso::L) ].push_back(ilepton);
-            if (leptons[ilepton].iso_T)
-                map_l[ lepIDIso(lepID::M, lepIso::T) ].push_back(ilepton);
-            if (leptons[ilepton].iso_HWW)
-                map_l[ lepIDIso(lepID::M, lepIso::HWW) ].push_back(ilepton);
-        }
-        if (leptons[ilepton].id_T)
-        {
-            map_l[ lepIDIso(lepID::T, lepIso::no) ].push_back(ilepton);
-            if (leptons[ilepton].iso_L)
-                map_l[ lepIDIso(lepID::T, lepIso::L) ].push_back(ilepton);
-            if (leptons[ilepton].iso_T)
-                map_l[ lepIDIso(lepID::T, lepIso::T) ].push_back(ilepton);
-            if (leptons[ilepton].iso_HWW)
-                map_l[ lepIDIso(lepID::T, lepIso::HWW) ].push_back(ilepton);
-        }
-        if (leptons[ilepton].id_HWW)
-        {
-            map_l[ lepIDIso(lepID::HWW, lepIso::no) ].push_back(ilepton);
-            if (leptons[ilepton].iso_L)
-                map_l[ lepIDIso(lepID::HWW, lepIso::L) ].push_back(ilepton);
-            if (leptons[ilepton].iso_T)
-                map_l[ lepIDIso(lepID::HWW, lepIso::T) ].push_back(ilepton);
-            if (leptons[ilepton].iso_HWW)
-                map_l[ lepIDIso(lepID::HWW, lepIso::HWW) ].push_back(ilepton);
-        }
-    }
-           
     for (unsigned int ilep1 = 0; ilep1 < leptons.size(); ilep1++)
     {
         if ((leptons[ilep1].isMu && leptons[ilep1].p4.Pt() < m_leadingMuonPtCut) || (leptons[ilep1].isEl && leptons[ilep1].p4.Pt() < m_leadingElectronPtCut)) continue;
@@ -284,56 +236,6 @@ void HHAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const 
                 tmp_count_has2leptons_mumu = event_weight;
             // Fill
             ll.push_back(dilep); 
-        }
-    }
-
-    // Fill dilepton maps
-    for (unsigned int i = 0; i < map_ll.size(); i++)
-        map_ll[i].clear();
-
-    // map is stored as lep1_ID, lep1_Iso, lep2_ID, lep2_Iso
-    // FIXME only dealing with symmetric cases for now
-    for (unsigned int ill = 0; ill < ll.size(); ill++)
-    {
-        if (ll[ill].id_LL)
-        {
-            map_ll[ leplepIDIso(lepID::L, lepIso::no, lepID::L, lepIso::no) ].push_back(ill);
-            if (ll[ill].iso_LL)
-                map_ll[ leplepIDIso(lepID::L, lepIso::L, lepID::L, lepIso::L) ].push_back(ill);
-            if (ll[ill].iso_TT)
-                map_ll[ leplepIDIso(lepID::L, lepIso::T, lepID::L, lepIso::T) ].push_back(ill);
-            if (ll[ill].iso_HWWHWW)
-                map_ll[ leplepIDIso(lepID::L, lepIso::HWW, lepID::L, lepIso::HWW) ].push_back(ill);
-        }
-        if (ll[ill].id_MM)
-        {
-            map_ll[ leplepIDIso(lepID::M, lepIso::no, lepID::M, lepIso::no) ].push_back(ill);
-            if (ll[ill].iso_LL)
-                map_ll[ leplepIDIso(lepID::M, lepIso::L, lepID::M, lepIso::L) ].push_back(ill);
-            if (ll[ill].iso_TT)
-                map_ll[ leplepIDIso(lepID::M, lepIso::T, lepID::M, lepIso::T) ].push_back(ill);
-            if (ll[ill].iso_HWWHWW)
-                map_ll[ leplepIDIso(lepID::M, lepIso::HWW, lepID::M, lepIso::HWW) ].push_back(ill);
-        }
-        if (ll[ill].id_TT)
-        {
-            map_ll[ leplepIDIso(lepID::T, lepIso::no, lepID::T, lepIso::no) ].push_back(ill);
-            if (ll[ill].iso_LL)
-                map_ll[ leplepIDIso(lepID::T, lepIso::L, lepID::T, lepIso::L) ].push_back(ill);
-            if (ll[ill].iso_TT)
-                map_ll[ leplepIDIso(lepID::T, lepIso::T, lepID::T, lepIso::T) ].push_back(ill);
-            if (ll[ill].iso_HWWHWW)
-                map_ll[ leplepIDIso(lepID::T, lepIso::HWW, lepID::T, lepIso::HWW) ].push_back(ill);
-        }
-        if (ll[ill].id_HWWHWW)
-        {
-            map_ll[ leplepIDIso(lepID::HWW, lepIso::no, lepID::HWW, lepIso::no) ].push_back(ill);
-            if (ll[ill].iso_LL)
-                map_ll[ leplepIDIso(lepID::HWW, lepIso::L, lepID::HWW, lepIso::L) ].push_back(ill);
-            if (ll[ill].iso_TT)
-                map_ll[ leplepIDIso(lepID::HWW, lepIso::T, lepID::HWW, lepIso::T) ].push_back(ill);
-            if (ll[ill].iso_HWWHWW)
-                map_ll[ leplepIDIso(lepID::HWW, lepIso::HWW, lepID::HWW, lepIso::HWW) ].push_back(ill);
         }
     }
 
@@ -439,28 +341,11 @@ void HHAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const 
         }
     }
 
-    // Fill dilepton+met maps
-    // FIXME: for now only store pf_met
-    // so ll and llmet structures are in sync
-    for (unsigned int i = 0; i < map_llmet.size(); i++)
-    {
-        map_llmet[i].clear();
-        for (unsigned int j = 0; j < map_ll[i].size(); j++)
-        {
-            map_llmet[i].push_back(map_ll[i][j]);
-        }
-    }
-
     // ***** 
     // Jets and dijets 
     // ***** 
     const JetsProducer& alljets = producers.get<JetsProducer>(m_jets_producer);
-    jets.clear();
-    for (unsigned int imap_j = 0; imap_j < map_j.size(); imap_j++)
-        map_j[imap_j].clear();
 
-    // (The following include filling up the jets map
-    int count = 0;
     for (unsigned int ijet = 0; ijet < alljets.p4.size(); ijet++)
     {
         float correctionFactor = m_applyBJetRegression ? alljets.regPt[ijet] / alljets.p4[ijet].Pt() : 1.;
@@ -499,57 +384,11 @@ void HHAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const 
             if (!myjet.id_L)
                 continue;
             jets.push_back(myjet);
-            // filling maps
-            // no jet ID
-            map_j[ jetIDbtagWP(jetID::no, btagWP::no) ].push_back(count);
-            if (myjet.btag_L)
-                map_j[ jetIDbtagWP(jetID::no, btagWP::L) ].push_back(count);
-            if (myjet.btag_M)
-                map_j[ jetIDbtagWP(jetID::no, btagWP::M) ].push_back(count);
-            if (myjet.btag_T)
-                map_j[ jetIDbtagWP(jetID::no, btagWP::T) ].push_back(count);
-            // loose jet ID
-            if (myjet.id_L)
-            {
-                map_j[ jetIDbtagWP(jetID::L, btagWP::no) ].push_back(count);
-                if (myjet.btag_L)
-                    map_j[ jetIDbtagWP(jetID::L, btagWP::L) ].push_back(count);
-                if (myjet.btag_M)
-                    map_j[ jetIDbtagWP(jetID::L, btagWP::M) ].push_back(count);
-                if (myjet.btag_T)
-                    map_j[ jetIDbtagWP(jetID::L, btagWP::T) ].push_back(count);
-            }
-            // tight jet ID
-            if (myjet.id_T)
-            {
-                map_j[ jetIDbtagWP(jetID::T, btagWP::no) ].push_back(count);
-                if (myjet.btag_L)
-                    map_j[ jetIDbtagWP(jetID::T, btagWP::L) ].push_back(count);
-                if (myjet.btag_M)
-                    map_j[ jetIDbtagWP(jetID::T, btagWP::M) ].push_back(count);
-                if (myjet.btag_T)
-                    map_j[ jetIDbtagWP(jetID::T, btagWP::T) ].push_back(count);
-            }
-            // tight jet ID lepton veto
-            if (myjet.id_TLV)
-            {
-                map_j[ jetIDbtagWP(jetID::TLV, btagWP::no) ].push_back(count);
-                if (myjet.btag_L)
-                    map_j[ jetIDbtagWP(jetID::TLV, btagWP::L) ].push_back(count);
-                if (myjet.btag_M)
-                    map_j[ jetIDbtagWP(jetID::TLV, btagWP::M) ].push_back(count);
-                if (myjet.btag_T)
-                    map_j[ jetIDbtagWP(jetID::TLV, btagWP::T) ].push_back(count);
-            }
-            count++;
         }
     }
 
     jj.clear();
     // Do NOT change the loop logic here: we expect [0] to be made out of the leading jets
-    for (unsigned int ijj = 0; ijj < map_jj.size(); ijj++)
-        map_jj[ijj].clear();
-    count = 0;
 
     for (unsigned int ijet1 = 0; ijet1 < jets.size(); ijet1++)
     {
@@ -586,88 +425,9 @@ void HHAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const 
             myjj.gen_cl = (jets[ijet1].gen_c && jets[ijet2].gen_l) || (jets[ijet1].gen_l && jets[ijet2].gen_c);
             myjj.gen_ll = (jets[ijet1].gen_l && jets[ijet2].gen_l);
             jj.push_back(myjj);
-            // fill dijet map
-            // FIXME for now only with symmetric cases
-            map_jj[ jetjetIDbtagWPPair(jetID::no, btagWP::no, jetID::no, btagWP::no, jetPair::ht) ].push_back(count);
-            if (myjj.btag_LL)
-                map_jj[ jetjetIDbtagWPPair(jetID::no, btagWP::L, jetID::no, btagWP::L, jetPair::ht) ].push_back(count);
-            if (myjj.btag_MM)
-                map_jj[ jetjetIDbtagWPPair(jetID::no, btagWP::M, jetID::no, btagWP::M, jetPair::ht) ].push_back(count);
-            if (myjj.btag_TT)
-                map_jj[ jetjetIDbtagWPPair(jetID::no, btagWP::T, jetID::no, btagWP::T, jetPair::ht) ].push_back(count);
-            if (jets[ijet1].id_L && jets[ijet2].id_L)
-            {
-                map_jj[ jetjetIDbtagWPPair(jetID::L, btagWP::no, jetID::L, btagWP::no, jetPair::ht) ].push_back(count);
-                if (myjj.btag_LL)
-                    map_jj[ jetjetIDbtagWPPair(jetID::L, btagWP::L, jetID::L, btagWP::L, jetPair::ht) ].push_back(count);
-                if (myjj.btag_MM)
-                    map_jj[ jetjetIDbtagWPPair(jetID::L, btagWP::M, jetID::L, btagWP::M, jetPair::ht) ].push_back(count);
-                if (myjj.btag_TT)
-                    map_jj[ jetjetIDbtagWPPair(jetID::L, btagWP::T, jetID::L, btagWP::T, jetPair::ht) ].push_back(count);
-            }
-            if (jets[ijet1].id_T && jets[ijet2].id_T)
-            {
-                map_jj[ jetjetIDbtagWPPair(jetID::T, btagWP::no, jetID::T, btagWP::no, jetPair::ht) ].push_back(count);
-                if (myjj.btag_LL)
-                    map_jj[ jetjetIDbtagWPPair(jetID::T, btagWP::L, jetID::T, btagWP::L, jetPair::ht) ].push_back(count);
-                if (myjj.btag_MM)
-                    map_jj[ jetjetIDbtagWPPair(jetID::T, btagWP::M, jetID::T, btagWP::M, jetPair::ht) ].push_back(count);
-                if (myjj.btag_TT)
-                    map_jj[ jetjetIDbtagWPPair(jetID::T, btagWP::T, jetID::T, btagWP::T, jetPair::ht) ].push_back(count);
-            }
-            if (jets[ijet1].id_TLV && jets[ijet2].id_TLV)
-            {
-                map_jj[ jetjetIDbtagWPPair(jetID::TLV, btagWP::no, jetID::TLV, btagWP::no, jetPair::ht) ].push_back(count);
-                if (myjj.btag_LL)
-                    map_jj[ jetjetIDbtagWPPair(jetID::TLV, btagWP::L, jetID::TLV, btagWP::L, jetPair::ht) ].push_back(count);
-                if (myjj.btag_MM)
-                    map_jj[ jetjetIDbtagWPPair(jetID::TLV, btagWP::M, jetID::TLV, btagWP::M, jetPair::ht) ].push_back(count);
-                if (myjj.btag_TT)
-                    map_jj[ jetjetIDbtagWPPair(jetID::TLV, btagWP::T, jetID::TLV, btagWP::T, jetPair::ht) ].push_back(count);
-            }
-            count++;
         }
     }
 
-    // Fill the rest of dijet combinatoric maps
-    for (const jetID::jetID& ijetid1: jetID::it)
-    {
-        for (const btagWP::btagWP& ibtag1: btagWP::it)
-        {
-            for (const jetID::jetID& ijetid2: jetID::it)
-            {
-                for (const btagWP::btagWP& ibtag2: btagWP::it)
-                {
-                    int iht = jetjetIDbtagWPPair(ijetid1, ibtag1, ijetid2, ibtag2, jetPair::ht);
-                    int jpt = jetjetIDbtagWPPair(ijetid1, ibtag1, ijetid2, ibtag2, jetPair::pt);
-                    int jmh = jetjetIDbtagWPPair(ijetid1, ibtag1, ijetid2, ibtag2, jetPair::mh);
-                    int jcsv = jetjetIDbtagWPPair(ijetid1, ibtag1, ijetid2, ibtag2, jetPair::csv);
-                    int jjp = jetjetIDbtagWPPair(ijetid1, ibtag1, ijetid2, ibtag2, jetPair::jp);
-                    int jptOverM = jetjetIDbtagWPPair(ijetid1, ibtag1, ijetid2, ibtag2, jetPair::ptOverM);
-                    std::vector<int> tmp = map_jj[iht];
-                    // do the ptjj sorted maps
-                    std::sort(tmp.begin(), tmp.end(), [&](const int& a, const int& b){return jj[a].p4.Pt() > jj[b].p4.Pt();});
-                    map_jj[jpt] = tmp;
-                    // do the closest to mh sorted maps
-                    tmp = map_jj[iht];
-                    std::sort(tmp.begin(), tmp.end(), [&](const int& a, const int& b){return fabs(jj[a].p4.M() - mh) < fabs(jj[b].p4.M() - mh);});
-                    map_jj[jmh] = tmp;
-                    // do the sum(btag) sorted maps
-                    tmp = map_jj[iht];
-                    std::sort(tmp.begin(), tmp.end(), [&](const int& a, const int& b){return jj[a].sumCSV > jj[b].sumCSV;});
-                    map_jj[jcsv] = tmp;
-                    tmp = map_jj[iht];
-                    std::sort(tmp.begin(), tmp.end(), [&](const int& a, const int& b){return jj[a].sumJP > jj[b].sumJP;});
-                    map_jj[jjp] = tmp;
-                    // do the ptjj / mjj sorted maps
-                    tmp = map_jj[iht];
-                    std::sort(tmp.begin(), tmp.end(), [&](const int& a, const int& b){return (jj[a].p4.Pt() / jj[a].p4.M()) > (jj[b].p4.Pt() / jj[b].p4.M());});
-                    map_jj[jptOverM] = tmp;
-                }
-            }
-        }
-    }
- 
     // ********** 
     // lljj, llbb, +pf_met
     // ********** 
@@ -831,86 +591,33 @@ void HHAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const 
         }
     }
 
-    if (HHANADEBUG) {std::cout << "##### Now debugging the llmetjj maps" << std::endl;}
-    // llmetjj maps: cross product of llmet and jj maps
-    for (unsigned int i = 0; i < map_llmetjj.size(); i++)
-        map_llmetjj[i].clear();
 
-    for (const lepID::lepID& il1id: lepID::it)
-    {
-        for (const lepIso::lepIso& il1iso: lepIso::it)
-        {
-            for (const lepID::lepID& il2id: lepID::it)
-            {
-                for (const lepIso::lepIso& il2iso: lepIso::it)
-                {
-                    for (const jetID::jetID& ij1id: jetID::it)
-                    {
-                        for (const btagWP::btagWP& ibtag1: btagWP::it)
-                        {
-                            for(const jetID::jetID& ij2id: jetID::it)
-                            {
-                                for(const btagWP::btagWP& ibtag2: btagWP::it)
-                                {
-                                    for(const jetPair::jetPair& ipair: jetPair::it)
-                                    {
-                                        int illmetjj = leplepIDIsojetjetIDbtagWPPair(il1id, il1iso, il2id, il2iso, ij1id, ibtag1, ij2id, ibtag2, ipair);
-                                        int illmet = leplepIDIso(il1id, il1iso, il2id, il2iso);
-                                        int ijj = jetjetIDbtagWPPair(ij1id, ibtag1, ij2id, ibtag2, ipair);
-                                        if (map_llmet[illmet].size() == 0 || map_jj[ijj].size() == 0)
-                                            continue;
-                                        if (HHANADEBUG)
-                                        {
-                                            std::cout << "Now treating illmetjj= " << illmetjj << " (illmet, ijj)= (" << illmet << ", " << ijj << ")" << std::endl;
-                                            std::cout << "map_llmet[" << illmet << "].size()= " << map_llmet[illmet].size() << std::endl;
-                                            for (unsigned int j = 0; j < map_llmet[illmet].size(); j++)
-                                                std::cout << "\tmap_llmet[" << illmet << "][" << j << "]= " << map_llmet[illmet][j] << std::endl;
-                                            std::cout << "map_jj[" << ijj << "].size()= " << map_jj[ijj].size() << std::endl;
-                                            for (unsigned int j = 0; j < map_jj[ijj].size(); j++)
-                                                std::cout << "\tmap_jj[" << ijj << "][" << j << "]= " << map_jj[ijj][j] << std::endl;
-                                        }
-                                        for (unsigned int jjj = 0; jjj < map_jj[ijj].size(); jjj++)
-                                        {
-                                            for (unsigned int i = 0; i < llmetjj.size(); i++)
-                                            {
-                                                if (std::find(map_llmet[illmet].begin(), map_llmet[illmet].end(), llmetjj[i].illmet) == map_llmet[illmet].end())
-                                                    continue;
-                                                if (llmetjj[i].ijj == map_jj[ijj][jjj])
-                                                {
-                                                    map_llmetjj[illmetjj].push_back(i);
-                                                    break;
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
+
+    // Sort the collections
+//    llmetjj_ht.clear(); llmetjj_ht = llmetjj;
+//    llmetjj_pt.clear(); llmetjj_pt = llmetjj;
+//    llmetjj_mh.clear(); llmetjj_mh = llmetjj;
+    llmetjj_csv.clear(); llmetjj_csv = llmetjj;
+//    llmetjj_ptOverM.clear(); llmetjj_ptOverM = llmetjj;
+//    std::sort(llmetjj_ht.begin(), llmetjj_ht.end(), [&](HH::DileptonMetDijet& a, const HH::DileptonMetDijet& b){return (a.jet1_p4.Pt() + a.jet2_p4.Pt()) > (b.jet1_p4.Pt() + bjet2_p4.Pt());});
+//    std::sort(llmetjj_pt.begin(), llmetjj_pt.end(), [&](HH::DileptonMetDijet& a, const HH::DileptonMetDijet& b){return a.jj_p4.Pt() > b.jj_p4.Pt();});
+//    std::sort(llmetjj_mh.begin(), llmetjj_mh.end(), [&](HH::DileptonMetDijet& a, const HH::DileptonMetDijet& b){return fabs(a.jj_p4.M() - mh) > fabs(b.jj_p4.M() - mh);});
+    std::sort(llmetjj_csv.begin(), llmetjj_csv.end(), [&](HH::DileptonMetDijet& a, const HH::DileptonMetDijet& b){return a.sumCSV > b.sumCSV;});
+//    std::sort(llmetjj_ptOverM.begin(), llmetjj_ptOverM.end(), [&](HH::DileptonMetDijet& a, const HH::DileptonMetDijet& b){return (a.jj_p4.Pt() / a.jj_p4.M()) > (b.jj_p4.Pt() / b.jj_p4.M());});
+
     // Adding some few custom candidates, for convenience
-    int icustom = leplepIDIsojetjetIDbtagWPPair(lepID::HWW, lepIso::HWW, lepID::HWW, lepIso::HWW, jetID::L, btagWP::no, jetID::L, btagWP::no, jetPair::csv);
-    llmetjj_HWWleptons_nobtag_csv.clear();
-    for (unsigned int icandidate = 0; icandidate < map_llmetjj[icustom].size(); icandidate++)
-        llmetjj_HWWleptons_nobtag_csv.push_back(llmetjj[map_llmetjj[icustom][icandidate]]);
-
-    icustom = leplepIDIsojetjetIDbtagWPPair(lepID::HWW, lepIso::HWW, lepID::HWW, lepIso::HWW, jetID::L, btagWP::L, jetID::L, btagWP::L, jetPair::csv);
-    llmetjj_HWWleptons_btagL_csv.clear();
-    for (unsigned int icandidate = 0; icandidate < map_llmetjj[icustom].size(); icandidate++)
-        llmetjj_HWWleptons_btagL_csv.push_back(llmetjj[map_llmetjj[icustom][icandidate]]);
-
-    icustom = leplepIDIsojetjetIDbtagWPPair(lepID::HWW, lepIso::HWW, lepID::HWW, lepIso::HWW, jetID::L, btagWP::M, jetID::L, btagWP::M, jetPair::csv);
-    llmetjj_HWWleptons_btagM_csv.clear();
-    for (unsigned int icandidate = 0; icandidate < map_llmetjj[icustom].size(); icandidate++)
-        llmetjj_HWWleptons_btagM_csv.push_back(llmetjj[map_llmetjj[icustom][icandidate]]);
-
-    icustom = leplepIDIsojetjetIDbtagWPPair(lepID::HWW, lepIso::HWW, lepID::HWW, lepIso::HWW, jetID::L, btagWP::T, jetID::L, btagWP::T, jetPair::csv);
-    llmetjj_HWWleptons_btagT_csv.clear();
-    for (unsigned int icandidate = 0; icandidate < map_llmetjj[icustom].size(); icandidate++)
-        llmetjj_HWWleptons_btagT_csv.push_back(llmetjj[map_llmetjj[icustom][icandidate]]);
+    for (auto &myllmetjj_csv: llmetjj_csv) {
+        if (!myllmetjj_csv.id_HWWHWW) continue;
+        if (!myllmetjj_csv.iso_HWWHWW) continue;
+        // jetID::L is enforced while filling the jet collection
+        llmetjj_HWWleptons_nobtag_csv.push_back(myllmetjj_csv);
+        if (myllmetjj_csv.btag_LL)
+            llmetjj_HWWleptons_btagL_csv.push_back(myllmetjj_csv);
+        if (myllmetjj_csv.btag_MM)
+            llmetjj_HWWleptons_btagM_csv.push_back(myllmetjj_csv);
+        if (myllmetjj_csv.btag_TT)
+            llmetjj_HWWleptons_btagT_csv.push_back(myllmetjj_csv);
+    }
 
 
     // ***** ***** *****

--- a/plugins/HHAnalyzer.cc
+++ b/plugins/HHAnalyzer.cc
@@ -205,6 +205,7 @@ void HHAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const 
             dilep.iso_HWWHWW = leptons[ilep1].iso_HWW && leptons[ilep2].iso_HWW;
             dilep.DR_l_l = ROOT::Math::VectorUtil::DeltaR(leptons[ilep1].p4, leptons[ilep2].p4);
             dilep.DPhi_l_l = fabs(ROOT::Math::VectorUtil::DeltaPhi(leptons[ilep1].p4, leptons[ilep2].p4));
+            dilep.ht_l_l = leptons[ilep1].p4.Pt() + leptons[ilep2].p4.Pt();
             if (!hlt.paths.empty()) dilep.hlt_idxs = std::make_pair(matchOfflineLepton(leptons[ilep1]),matchOfflineLepton(leptons[ilep2]));
             dilep.gen_matched = leptons[ilep1].gen_matched && leptons[ilep2].gen_matched;
             dilep.gen_p4 = dilep.gen_matched ? leptons[ilep1].gen_p4 + leptons[ilep2].gen_p4 : null_p4;
@@ -242,7 +243,7 @@ void HHAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const 
         }
     }
     // have the ll collection sorted by ht
-    std::sort(ll.begin(), ll.end(), [&](HH::Dilepton& a, HH::Dilepton& b){return a.p4.Pt() > b.p4.Pt();});
+    std::sort(ll.begin(), ll.end(), [&](HH::Dilepton& a, HH::Dilepton& b){return a.ht_l_l > b.ht_l_l;});
 
     // ***** 
     // Adding MET(s)
@@ -326,6 +327,7 @@ void HHAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const 
             myllmet.iso_HWWHWW = ll[ill].iso_HWWHWW;
             myllmet.DR_l_l = ll[ill].DR_l_l;
             myllmet.DPhi_l_l = ll[ill].DPhi_l_l;
+            myllmet.ht_l_l = ll[ill].ht_l_l;
             // content specific to HH:DileptonMet
             myllmet.ill = ill;
             myllmet.imet = imet;
@@ -421,6 +423,7 @@ void HHAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const 
             myjj.sumJP = jets[ijet1].JP + jets[ijet2].JP;
             myjj.DR_j_j = ROOT::Math::VectorUtil::DeltaR(jets[ijet1].p4, jets[ijet2].p4);
             myjj.DPhi_j_j = fabs(ROOT::Math::VectorUtil::DeltaPhi(jets[ijet1].p4, jets[ijet2].p4));
+            myjj.ht_j_j = jets[ijet1].p4.Pt() + jets[ijet2].p4.Pt();
             myjj.gen_matched_bbPartons = jets[ijet1].gen_matched_bParton && jets[ijet2].gen_matched_bParton; 
             myjj.gen_matched_bbHadrons = jets[ijet1].gen_matched_bHadron && jets[ijet2].gen_matched_bHadron; 
             myjj.gen_matched = jets[ijet1].gen_matched && jets[ijet2].gen_matched;
@@ -496,6 +499,7 @@ void HHAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const 
             myllmetjj.sumJP = jj[ijj].sumJP;
             myllmetjj.DR_j_j = jj[ijj].DR_j_j;
             myllmetjj.DPhi_j_j = jj[ijj].DPhi_j_j;
+            myllmetjj.ht_j_j = jj[ijj].ht_j_j;
             myllmetjj.gen_matched_bbPartons = jj[ijj].gen_matched_bbPartons;
             myllmetjj.gen_matched_bbHadrons = jj[ijj].gen_matched_bbHadrons;
             myllmetjj.gen_bb = jj[ijj].gen_bb;
@@ -542,6 +546,7 @@ void HHAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const 
             myllmetjj.iso_HWWHWW = ll[ill].iso_HWWHWW;
             myllmetjj.DR_l_l = ll[ill].DR_l_l;
             myllmetjj.DPhi_l_l = ll[ill].DPhi_l_l;
+            myllmetjj.ht_l_l = ll[ill].ht_l_l;
             myllmetjj.trigger_efficiency = ll[ill].trigger_efficiency;
             myllmetjj.trigger_efficiency_downVariated = ll[ill].trigger_efficiency_downVariated;
             myllmetjj.trigger_efficiency_downVariated_Arun = ll[ill].trigger_efficiency_downVariated_Arun;

--- a/src/classes.h
+++ b/src/classes.h
@@ -19,5 +19,6 @@ namespace {
         HH::DileptonMetDijet dummy14;
         std::vector<HH::DileptonMetDijet> dummy15;
         std::pair<int8_t, int8_t>  dummy16;
+        HH::MELAAngles dummy17;
     };
 }

--- a/src/classes_def.xml
+++ b/src/classes_def.xml
@@ -17,4 +17,5 @@
     <class name="HH::DileptonMetDijet"/>
     <class name="std::vector<HH::DileptonMetDijet>"/>
     <class name="std::pair<int8_t, int8_t>"/>
+    <class name="HH::MELAAngles"/>
 </lcgdict>


### PR DESCRIPTION
list of changes:
- getting rid of maps (spéciale dédicace @BrieucF)
- ll and jj candidates sorted by ht (fix #61)
- introduce the MELA-like angles (see #59)
  - with only the visible particles
  - or considering llmet as the H(ww) leg + only visible legs
- add some asymmetric btag candidates (see #59)
- store more jetID info into candidates (fix #80)
- add some PlusMinus booleans to prepare for matrix element analysis (see #3)

Notes:
- [x] https://github.com/cp3-llbb/HHAnalysis/pull/100 needs to be merged first
