### PR TITLE
Add support for per-category lepton pt cuts

### DIFF
--- a/interface/Categories.h
+++ b/interface/Categories.h
@@ -14,6 +14,10 @@ class DileptonCategory: public Category {
         }
     private:
         std::string m_analyzer_name;
+
+    protected:
+        float m_leadingLeptonPtCut;
+        float m_subleadingLeptonPtCut;
 };
 
 class MuMuCategory: public DileptonCategory {
@@ -21,6 +25,7 @@ class MuMuCategory: public DileptonCategory {
     virtual bool event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
     virtual void register_cuts(CutManager& manager) override;
     virtual void evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
+    virtual void configure(const edm::ParameterSet& conf) override;
 };
 
 class ElElCategory: public DileptonCategory {
@@ -28,6 +33,7 @@ class ElElCategory: public DileptonCategory {
     virtual bool event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
     virtual void register_cuts(CutManager& manager) override;
     virtual void evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
+    virtual void configure(const edm::ParameterSet& conf) override;
 };
 
 class ElMuCategory: public DileptonCategory {
@@ -35,6 +41,7 @@ class ElMuCategory: public DileptonCategory {
     virtual bool event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
     virtual void register_cuts(CutManager& manager) override;
     virtual void evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
+    virtual void configure(const edm::ParameterSet& conf) override;
 };
 
 class MuElCategory: public DileptonCategory {
@@ -42,6 +49,7 @@ class MuElCategory: public DileptonCategory {
     virtual bool event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
     virtual void register_cuts(CutManager& manager) override;
     virtual void evaluate_cuts_post_analyzers(CutManager& manager, const ProducersManager& producers, const AnalyzersManager& analyzers) const override;
+    virtual void configure(const edm::ParameterSet& conf) override;
 };
 
 #endif

--- a/interface/HHAnalyzer.h
+++ b/interface/HHAnalyzer.h
@@ -232,7 +232,6 @@ class HHAnalyzer: public Framework::Analyzer {
         std::string m_electron_tight_wp_name;
         bool m_applyBJetRegression;
         std::unordered_map<std::string, std::unique_ptr<BinnedValues>> m_hlt_efficiencies;
-
 };
 
 // Some macros for gen information

--- a/plugins/Categories.cc
+++ b/plugins/Categories.cc
@@ -32,20 +32,34 @@ const std::vector<HH::DileptonMetDijet>& DileptonCategory::getDileptonMetDijets(
 // ***** ***** *****
 // Dilepton Mu-Mu category
 // ***** ***** *****
+
+void MuMuCategory::configure(const edm::ParameterSet& conf) {
+    DileptonCategory::configure(conf);
+
+    m_leadingLeptonPtCut = conf.getUntrackedParameter<double>("mumu_leadingLeptonPtCut");
+    m_subleadingLeptonPtCut = conf.getUntrackedParameter<double>("mumu_subleadingLeptonPtCut");
+}
+
 bool MuMuCategory::event_in_category_pre_analyzers(const ProducersManager& producers) const {
     const MuonsProducer& muons = producers.get<MuonsProducer>("muons");
     return (muons.p4.size() >= 2);
 };
 
 bool MuMuCategory::event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const {
+    const std::vector<HH::Lepton>& leptons = getLeptons(analyzers);
     const std::vector<HH::Dilepton>& ll = getDileptons(analyzers);
     const std::vector<HH::DileptonMetDijet>& llmetjj = getDileptonMetDijets(analyzers);
-    bool isMuMu = false;
-    for (unsigned int idilep = 0; idilep < ll.size(); idilep++) 
-    {
-        if (ll[idilep].isMuMu) isMuMu = true;
-    }
-    return (isMuMu && llmetjj.size() > 0);
+
+    if (ll.empty())
+        return false;
+
+    if (llmetjj.empty())
+        return false;
+
+    // Only look at the first dilepton pair
+    return ll[0].isMuMu &&
+        (leptons[ll[0].ilep1].p4.Pt() > m_leadingLeptonPtCut) &&
+        (leptons[ll[0].ilep2].p4.Pt() > m_subleadingLeptonPtCut);
 };
 
 void MuMuCategory::register_cuts(CutManager& manager) {
@@ -65,20 +79,34 @@ void MuMuCategory::evaluate_cuts_post_analyzers(CutManager& manager, const Produ
 // ***** ***** *****
 // Dilepton El-El category
 // ***** ***** *****
+
+void ElElCategory::configure(const edm::ParameterSet& conf) {
+    DileptonCategory::configure(conf);
+
+    m_leadingLeptonPtCut = conf.getUntrackedParameter<double>("elel_leadingLeptonPtCut");
+    m_subleadingLeptonPtCut = conf.getUntrackedParameter<double>("elel_subleadingLeptonPtCut");
+}
+
 bool ElElCategory::event_in_category_pre_analyzers(const ProducersManager& producers) const {
     const ElectronsProducer& electrons = producers.get<ElectronsProducer>("electrons");
     return (electrons.p4.size() >= 2);
 };
 
 bool ElElCategory::event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const {
+    const std::vector<HH::Lepton>& leptons = getLeptons(analyzers);
     const std::vector<HH::Dilepton>& ll = getDileptons(analyzers);
     const std::vector<HH::DileptonMetDijet>& llmetjj = getDileptonMetDijets(analyzers);
-    bool isElEl = false;
-    for (unsigned int idilep = 0; idilep < ll.size(); idilep++) 
-    {
-        if (ll[idilep].isElEl) isElEl = true;
-    }
-    return (isElEl && llmetjj.size() > 0);
+
+    if (ll.empty())
+        return false;
+
+    if (llmetjj.empty())
+        return false;
+
+    // Only look at the first dilepton pair
+    return ll[0].isElEl &&
+        (leptons[ll[0].ilep1].p4.Pt() > m_leadingLeptonPtCut) &&
+        (leptons[ll[0].ilep2].p4.Pt() > m_subleadingLeptonPtCut);
 };
 
 void ElElCategory::register_cuts(CutManager& manager) {
@@ -98,6 +126,14 @@ void ElElCategory::evaluate_cuts_post_analyzers(CutManager& manager, const Produ
 // ***** ***** *****
 // Dilepton El-Mu category
 // ***** ***** *****
+
+void ElMuCategory::configure(const edm::ParameterSet& conf) {
+    DileptonCategory::configure(conf);
+
+    m_leadingLeptonPtCut = conf.getUntrackedParameter<double>("elmu_leadingLeptonPtCut");
+    m_subleadingLeptonPtCut = conf.getUntrackedParameter<double>("elmu_subleadingLeptonPtCut");
+}
+
 bool ElMuCategory::event_in_category_pre_analyzers(const ProducersManager& producers) const {
     const ElectronsProducer& electrons = producers.get<ElectronsProducer>("electrons");
     const MuonsProducer& muons = producers.get<MuonsProducer>("muons");
@@ -105,14 +141,20 @@ bool ElMuCategory::event_in_category_pre_analyzers(const ProducersManager& produ
 };
 
 bool ElMuCategory::event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const {
+    const std::vector<HH::Lepton>& leptons = getLeptons(analyzers);
     const std::vector<HH::Dilepton>& ll = getDileptons(analyzers);
     const std::vector<HH::DileptonMetDijet>& llmetjj = getDileptonMetDijets(analyzers);
-    bool isElMu = false;
-    for (unsigned int idilep = 0; idilep < ll.size(); idilep++) 
-    {
-        if (ll[idilep].isElMu) isElMu = true;
-    }
-    return (isElMu && llmetjj.size() > 0);
+
+    if (ll.empty())
+        return false;
+
+    if (llmetjj.empty())
+        return false;
+
+    // Only look at the first dilepton pair
+    return ll[0].isElMu &&
+        (leptons[ll[0].ilep1].p4.Pt() > m_leadingLeptonPtCut) &&
+        (leptons[ll[0].ilep2].p4.Pt() > m_subleadingLeptonPtCut);
 };
 
 void ElMuCategory::register_cuts(CutManager& manager) {
@@ -132,6 +174,14 @@ void ElMuCategory::evaluate_cuts_post_analyzers(CutManager& manager, const Produ
 // ***** ***** *****
 // Dilepton Mu-El category
 // ***** ***** *****
+
+void MuElCategory::configure(const edm::ParameterSet& conf) {
+    DileptonCategory::configure(conf);
+
+    m_leadingLeptonPtCut = conf.getUntrackedParameter<double>("muel_leadingLeptonPtCut");
+    m_subleadingLeptonPtCut = conf.getUntrackedParameter<double>("muel_subleadingLeptonPtCut");
+}
+
 bool MuElCategory::event_in_category_pre_analyzers(const ProducersManager& producers) const {
     const ElectronsProducer& electrons = producers.get<ElectronsProducer>("electrons");
     const MuonsProducer& muons = producers.get<MuonsProducer>("muons");
@@ -139,14 +189,20 @@ bool MuElCategory::event_in_category_pre_analyzers(const ProducersManager& produ
 };
 
 bool MuElCategory::event_in_category_post_analyzers(const ProducersManager& producers, const AnalyzersManager& analyzers) const {
+    const std::vector<HH::Lepton>& leptons = getLeptons(analyzers);
     const std::vector<HH::Dilepton>& ll = getDileptons(analyzers);
     const std::vector<HH::DileptonMetDijet>& llmetjj = getDileptonMetDijets(analyzers);
-    bool isMuEl = false;
-    for (unsigned int idilep = 0; idilep < ll.size(); idilep++) 
-    {
-        if (ll[idilep].isMuEl) isMuEl = true;
-    }
-    return (isMuEl && llmetjj.size() > 0);
+
+    if (ll.empty())
+        return false;
+
+    if (llmetjj.empty())
+        return false;
+
+    // Only look at the first dilepton pair
+    return ll[0].isMuEl &&
+        (leptons[ll[0].ilep1].p4.Pt() > m_leadingLeptonPtCut) &&
+        (leptons[ll[0].ilep2].p4.Pt() > m_subleadingLeptonPtCut);
 };
 
 void MuElCategory::register_cuts(CutManager& manager) {
@@ -162,4 +218,3 @@ void MuElCategory::evaluate_cuts_post_analyzers(CutManager& manager, const Produ
         }
     }
 }
-

--- a/test/HHConfiguration.py
+++ b/test/HHConfiguration.py
@@ -21,6 +21,17 @@ framework.addAnalyzer('hh_analyzer', cms.PSet(
         type = cms.string('hh_analyzer'),
         prefix = cms.string('hh_'),
         enable = cms.bool(True),
+        categories_parameters = cms.PSet(
+            # Per-category lepton pt cuts
+            mumu_leadingLeptonPtCut = cms.untracked.double(20), # muon
+            mumu_subleadingLeptonPtCut = cms.untracked.double(10), # muon
+            elel_leadingLeptonPtCut = cms.untracked.double(25), # electron
+            elel_subleadingLeptonPtCut = cms.untracked.double(15), # electron
+            muel_leadingLeptonPtCut = cms.untracked.double(25), # muon
+            muel_subleadingLeptonPtCut = cms.untracked.double(15), # electron
+            elmu_leadingLeptonPtCut = cms.untracked.double(25), # electron
+            elmu_subleadingLeptonPtCut = cms.untracked.double(10), # muon
+        ),
         parameters = cms.PSet(
             # Producers
             electronsProducer = cms.string('electrons'),
@@ -28,14 +39,16 @@ framework.addAnalyzer('hh_analyzer', cms.PSet(
             jetsProducer = cms.string('jets'),
             metProducer = cms.string('met'),
             nohfMETProducer = cms.string('nohf_met'),
-            # Here are the default value (just to show what is configurable)
-            leadingElectronPtCut = cms.untracked.double(20),
+
+            # Pre-selection pt cut, applied to all leptons
+            leadingElectronPtCut = cms.untracked.double(25),
             subleadingElectronPtCut = cms.untracked.double(15),
+            leadingMuonPtCut = cms.untracked.double(20),
+            subleadingMuonPtCut = cms.untracked.double(10),
+
             electronEtaCut = cms.untracked.double(2.5),
             muonLooseIsoCut = cms.untracked.double(.25), # https://twiki.cern.ch/twiki/bin/view/CMS/TopMUO 
             muonTightIsoCut = cms.untracked.double(.15), # https://twiki.cern.ch/twiki/bin/view/CMS/TopMUO 
-            leadingMuonPtCut = cms.untracked.double(20),
-            subleadingMuonPtCut = cms.untracked.double(10),
             muonEtaCut = cms.untracked.double(2.4),
             electrons_loose_wp_name = cms.untracked.string("cutBasedElectronID-Summer16-80X-V1-loose"),
             electrons_medium_wp_name = cms.untracked.string("cutBasedElectronID-Summer16-80X-V1-medium"),


### PR DESCRIPTION
Categories are now exlusive and based on the first dilepton pair.

Category flags will need to be used in histFactory instead of simply checking if the flavor of the first pair.

Pt cuts are those discussed on slack.