### PR TITLE
Move to cMVAv2 b-tagging discriminant

### DIFF
--- a/interface/HHAnalyzer.h
+++ b/interface/HHAnalyzer.h
@@ -82,16 +82,16 @@ class HHAnalyzer: public Framework::Analyzer {
         std::vector<HH::DileptonMet> llmet;
         std::vector<HH::Dijet> jj;
         std::vector<HH::DileptonMetDijet> llmetjj;
-        std::vector<HH::DileptonMetDijet> llmetjj_csv;
+        std::vector<HH::DileptonMetDijet> llmetjj_cmva;
         // some few custom candidates, for convenience
         // Januray 2016: preapproval freezing custom candidates
-        BRANCH(llmetjj_HWWleptons_nobtag_csv, std::vector<HH::DileptonMetDijet>);
-        BRANCH(llmetjj_HWWleptons_btagL_csv, std::vector<HH::DileptonMetDijet>);
-        BRANCH(llmetjj_HWWleptons_btagM_csv, std::vector<HH::DileptonMetDijet>);
-        BRANCH(llmetjj_HWWleptons_btagT_csv, std::vector<HH::DileptonMetDijet>);
+        BRANCH(llmetjj_HWWleptons_nobtag_cmva, std::vector<HH::DileptonMetDijet>);
+        BRANCH(llmetjj_HWWleptons_btagL_cmva, std::vector<HH::DileptonMetDijet>);
+        BRANCH(llmetjj_HWWleptons_btagM_cmva, std::vector<HH::DileptonMetDijet>);
+        BRANCH(llmetjj_HWWleptons_btagT_cmva, std::vector<HH::DileptonMetDijet>);
         // October 2016: adding some asymmetric btag candidates, for study
-        BRANCH(llmetjj_HWWleptons_btagLM_csv, std::vector<HH::DileptonMetDijet>);
-        BRANCH(llmetjj_HWWleptons_btagMT_csv, std::vector<HH::DileptonMetDijet>);
+        BRANCH(llmetjj_HWWleptons_btagLM_cmva, std::vector<HH::DileptonMetDijet>);
+        BRANCH(llmetjj_HWWleptons_btagMT_cmva, std::vector<HH::DileptonMetDijet>);
 
         virtual void analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager&, const AnalyzersManager&, const CategoryManager&) override;
         virtual void registerCategories(CategoryManager& manager, const edm::ParameterSet& config) override;

--- a/interface/Types.h
+++ b/interface/Types.h
@@ -120,7 +120,7 @@ namespace HH {
         bool btag_M;
         bool btag_T;
         float CSV;
-        float JP;
+        float CMVAv2;
         bool gen_matched_bParton;
         bool gen_matched_bHadron;
         bool gen_matched;
@@ -149,7 +149,7 @@ namespace HH {
         bool btag_TM;
         bool btag_TT;
         float sumCSV;
-        float sumJP;
+        float sumCMVAv2;
         float DR_j_j;
         float DPhi_j_j;
         float ht_j_j;

--- a/src/classes_def.xml
+++ b/src/classes_def.xml
@@ -1,21 +1,36 @@
 <lcgdict>
-    <class name="HH::Lepton">
-        <field name="hlt_already_tried_matching" transient="true"/>
+    <class name="HH::Lepton" ClassVersion="10">
+     <version ClassVersion="10" checksum="1833596599"/>
+     <field name="hlt_already_tried_matching" transient="true"/>
     </class>
     <class name="std::vector<HH::Lepton>"/>
-    <class name="HH::Dilepton"/>
+    <class name="HH::Dilepton" ClassVersion="10">
+     <version ClassVersion="10" checksum="2433355583"/>
+    </class>
     <class name="std::vector<HH::Dilepton>"/>
-    <class name="HH::Met"/>
+    <class name="HH::Met" ClassVersion="10">
+     <version ClassVersion="10" checksum="1356748875"/>
+    </class>
     <class name="std::vector<HH::Met>"/>
-    <class name="HH::DileptonMet"/>
+    <class name="HH::DileptonMet" ClassVersion="10">
+     <version ClassVersion="10" checksum="2202889764"/>
+    </class>
     <class name="std::vector<HH::DileptonMet>"/>
     <class name="std::vector< std::vector<int> >"/>
-    <class name="HH::Jet"/>
+    <class name="HH::Jet" ClassVersion="10">
+     <version ClassVersion="10" checksum="194867656"/>
+    </class>
     <class name="std::vector<HH::Jet>"/>
-    <class name="HH::Dijet"/>
+    <class name="HH::Dijet" ClassVersion="10">
+     <version ClassVersion="10" checksum="2119876344"/>
+    </class>
     <class name="std::vector<HH::Dijet>"/>
-    <class name="HH::DileptonMetDijet"/>
+    <class name="HH::DileptonMetDijet" ClassVersion="10">
+     <version ClassVersion="10" checksum="1966451846"/>
+    </class>
     <class name="std::vector<HH::DileptonMetDijet>"/>
     <class name="std::pair<int8_t, int8_t>"/>
-    <class name="HH::MELAAngles"/>
+    <class name="HH::MELAAngles" ClassVersion="10">
+     <version ClassVersion="10" checksum="2939888277"/>
+    </class>
 </lcgdict>

--- a/test/HHConfiguration.py
+++ b/test/HHConfiguration.py
@@ -56,11 +56,14 @@ framework.addAnalyzer('hh_analyzer', cms.PSet(
             electrons_hlt_safe_wp_name = cms.untracked.string("cutBasedElectronHLTPreselection-Summer16-V1"),
             jetEtaCut = cms.untracked.double(2.4),
             jetPtCut = cms.untracked.double(20),
+
             # BTAG INFO
-            discr_name =  cms.untracked.string("pfCombinedInclusiveSecondaryVertexV2BJetTags"),
-            discr_cut_loose =  cms.untracked.double(0.460),
-            discr_cut_medium =  cms.untracked.double(0.800),
-            discr_cut_tight =  cms.untracked.double(0.935),
+            # Working points from https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation80X
+            discr_name =  cms.untracked.string("pfCombinedMVAV2BJetTags"),
+            discr_cut_loose =  cms.untracked.double(-0.715),
+            discr_cut_medium =  cms.untracked.double(0.185),
+            discr_cut_tight =  cms.untracked.double(0.875),
+
             minDR_l_j_Cut = cms.untracked.double(0.3),
             hltDRCut = cms.untracked.double(0.1),
             hltDPtCut = cms.untracked.double(0.5),  # cut will be DPt/Pt < hltDPtCut


### PR DESCRIPTION
As agreed (kind of) IRL, this PR moves from CSVv2 to cMVAv2 for b-tagger.

  - I renamed all branches from `_csv` to `_cmva`.
  - I replaced the field `JP` in our structures by `CMVAv2`. Since it's just a renaming, previous dictionaries remain fully compatible.
  - I updated the b-tag WPs with the cMVA recommendations
  - I added a `ClassVersion` inside our dictionaries. Recently, there have been cases where one tried to read ntuples produced with a version X of the dict using version Y. There is currently no error, but everything is messed up (wrong sizes of collections, garbage content, etc.). `ClassVersion` helps here to prevent this situation to occurs: ROOT will automatically check that the `ClassVersion` used to produce the ntuples is the same than the one used to read them.