### PR TITLE
Ensure all branches are created during the first event

### DIFF
--- a/interface/HHAnalyzer.h
+++ b/interface/HHAnalyzer.h
@@ -92,7 +92,7 @@ class HHAnalyzer: public Framework::Analyzer {
         //// October 2016: adding some asymmetric btag candidates, for study
         //BRANCH(llmetjj_HWWleptons_btagLM_cmva, std::vector<HH::DileptonMetDijet>);
         //BRANCH(llmetjj_HWWleptons_btagMT_cmva, std::vector<HH::DileptonMetDijet>);
-        
+
         BRANCH(llmetjj, std::vector<HH::DileptonMetDijet>);
 
         virtual void analyze(const edm::Event&, const edm::EventSetup&, const ProducersManager&, const AnalyzersManager&, const CategoryManager&) override;
@@ -207,6 +207,20 @@ class HHAnalyzer: public Framework::Analyzer {
         ONLY_NOMINAL_BRANCH(gen_iNu2, char);
         ONLY_NOMINAL_BRANCH(gen_Nu1, LorentzVector);
         ONLY_NOMINAL_BRANCH(gen_Nu2, LorentzVector);
+
+        ONLY_NOMINAL_BRANCH(gen_deltaR_jet_B, std::vector<float>);
+        ONLY_NOMINAL_BRANCH(gen_deltaR_jet_Bbar, std::vector<float>);
+        ONLY_NOMINAL_BRANCH(gen_deltaR_jet_B_afterFSR, std::vector<float>);
+        ONLY_NOMINAL_BRANCH(gen_deltaR_jet_Bbar_afterFSR, std::vector<float>);
+        ONLY_NOMINAL_BRANCH(gen_deltaR_electron_L1, std::vector<float>);
+        ONLY_NOMINAL_BRANCH(gen_deltaR_electron_L2, std::vector<float>);
+        ONLY_NOMINAL_BRANCH(gen_deltaR_electron_L1_afterFSR, std::vector<float>);
+        ONLY_NOMINAL_BRANCH(gen_deltaR_electron_L2_afterFSR, std::vector<float>);
+        ONLY_NOMINAL_BRANCH(gen_deltaR_muon_L1, std::vector<float>);
+        ONLY_NOMINAL_BRANCH(gen_deltaR_muon_L2, std::vector<float>);
+        ONLY_NOMINAL_BRANCH(gen_deltaR_muon_L1_afterFSR, std::vector<float>);
+        ONLY_NOMINAL_BRANCH(gen_deltaR_muon_L2_afterFSR, std::vector<float>);
+
 
     private:
         // Producers name

--- a/plugins/HHAnalyzer.cc
+++ b/plugins/HHAnalyzer.cc
@@ -265,19 +265,6 @@ void HHAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const 
         // ***** ***** *****
         // Matching
         // ***** ***** *****
-        ONLY_NOMINAL_BRANCH(gen_deltaR_jet_B, std::vector<float>);    
-        ONLY_NOMINAL_BRANCH(gen_deltaR_jet_Bbar, std::vector<float>);    
-        ONLY_NOMINAL_BRANCH(gen_deltaR_jet_B_afterFSR, std::vector<float>);    
-        ONLY_NOMINAL_BRANCH(gen_deltaR_jet_Bbar_afterFSR, std::vector<float>);    
-        ONLY_NOMINAL_BRANCH(gen_deltaR_electron_L1, std::vector<float>);    
-        ONLY_NOMINAL_BRANCH(gen_deltaR_electron_L2, std::vector<float>);    
-        ONLY_NOMINAL_BRANCH(gen_deltaR_electron_L1_afterFSR, std::vector<float>);    
-        ONLY_NOMINAL_BRANCH(gen_deltaR_electron_L2_afterFSR, std::vector<float>);    
-        ONLY_NOMINAL_BRANCH(gen_deltaR_muon_L1, std::vector<float>);    
-        ONLY_NOMINAL_BRANCH(gen_deltaR_muon_L2, std::vector<float>);    
-        ONLY_NOMINAL_BRANCH(gen_deltaR_muon_L1_afterFSR, std::vector<float>);    
-        ONLY_NOMINAL_BRANCH(gen_deltaR_muon_L2_afterFSR, std::vector<float>);    
-    
         for (auto p4: alljets.gen_p4) {
             gen_deltaR_jet_B.push_back(deltaR(p4, gen_B));
             gen_deltaR_jet_Bbar.push_back(deltaR(p4, gen_Bbar));


### PR DESCRIPTION
We have some branches that are created directly inside the code, inside a `if` block. After the addition of the taus workaround, it may happen that the first processed event is thrown away because it's a tau event. If it's the case, the branches are **not** created on the first event, but on the second or third one, meaning the number of entries in these branches will be different than other branches, which is **not** what we want.

The fix is simple: move branches declaration into the class declaration, ensuring all the branches are created when the class is created.