### PR TITLE
More detailed L1 EMTF mitigation

### DIFF
--- a/interface/HHAnalyzer.h
+++ b/interface/HHAnalyzer.h
@@ -103,6 +103,19 @@ class HHAnalyzer: public Framework::Analyzer {
         MELAAngles getMELAAngles(const LorentzVector &q1, const LorentzVector &q2, const LorentzVector &q11, const LorentzVector &q12, const LorentzVector &q21, const LorentzVector &q22, float ebeam = 6500);
         void matchOfflineLepton(const HLTProducer& hlt, Dilepton& dilepton);
         void fillTriggerEfficiencies(const Lepton & lep1, const Lepton & lep2, Dilepton & dilep);
+        
+        // Stuff for L1 EMTF muon mitigation
+        float getL1TPhi(int charge, const LorentzVector& p);
+        bool sameEndCap(const LorentzVector& p1, const LorentzVector& p2);
+        // Translate phi by 'translation', and put it into [0, 2pi[
+        float translatePhi(float phi, float translation=0);
+        // Get N s.t. start + 60° * N <= phi < end + 60° + N; return -1 if no such N
+        int getPhiSector(float phi, float start, float end);
+        // See https://twiki.cern.ch/twiki/bin/view/CMS/EndcapHighPtMuonEfficiencyProblem:
+        // Case 2) -- using gen info (to apply weights on MC)
+        bool isCSCSameSector(const Lepton& lep1, const Lepton& lep2);
+        // Case 3) -- using reco info (to reject data and MC)
+        bool isCSCWithOverlap(const Lepton& lep1, const Lepton& lep2);
 
         // global event stuff (selected objects multiplicity)
         BRANCH(HT, float);

--- a/plugins/HHAnalyzer.cc
+++ b/plugins/HHAnalyzer.cc
@@ -427,17 +427,21 @@ void HHAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const 
             dilep.gen_p4 = dilep.gen_matched ? leptons[ilep1].gen_p4 + leptons[ilep2].gen_p4 : null_p4;
             dilep.gen_DR = dilep.gen_matched ? ROOT::Math::VectorUtil::DeltaR(dilep.p4, dilep.gen_p4) : -1.;
             dilep.gen_DPtOverPt = dilep.gen_matched ? (dilep.p4.Pt() - dilep.gen_p4.Pt()) / dilep.p4.Pt() : -10.;
+
             if (event.isRealData()) {
                dilep.trigger_efficiency = 1.;
                dilep.trigger_efficiency_downVariated = 1.;
                dilep.trigger_efficiency_upVariated = 1.;
-            }
-            else {
+            } else {
                fillTriggerEfficiencies(leptons[ilep1], leptons[ilep2], dilep);
             }
             // Some selection
             // Note that ID and isolation criteria are in both electron and muon loops
             if (!dilep.isOS)
+                continue;
+
+            // FIXME L1 EMTF bug mitigation -- cut the overlap on both MC and data
+            if (dilep.isMuMu && isCSCWithOverlap(leptons[ilep1], leptons[ilep2]))
                 continue;
 
             // Throw event if there is no matched dilepton trigger path (only on data)

--- a/plugins/Tools.cc
+++ b/plugins/Tools.cc
@@ -340,10 +340,12 @@ void HHAnalyzer::matchOfflineLepton(const HLTProducer& hlt, HH::Dilepton& dilept
 }
 
 float HHAnalyzer::getL1TPhi(int charge, const LorentzVector& p) {
-    float pt = p.Pt();
+    /*float pt = p.Pt();
     float phi = p.Phi();
     float theta = p.Theta();
-    return phi + charge * (1. / pt) * (10.48 - 5.1412 * theta + 0.02308 * theta * theta);
+    return phi + charge * (1. / pt) * (10.48 - 5.1412 * theta + 0.02308 * theta * theta);*/
+    // FIXME
+    return p.Phi();
 }
 
 bool HHAnalyzer::sameEndCap(const LorentzVector& p1, const LorentzVector& p2) {

--- a/plugins/Tools.cc
+++ b/plugins/Tools.cc
@@ -339,6 +339,76 @@ void HHAnalyzer::matchOfflineLepton(const HLTProducer& hlt, HH::Dilepton& dilept
     }
 }
 
+float HHAnalyzer::getL1TPhi(int charge, const LorentzVector& p) {
+    float pt = p.Pt();
+    float phi = p.Phi();
+    float theta = p.Theta();
+    return phi + charge * (1. / pt) * (10.48 - 5.1412 * theta + 0.02308 * theta * theta);
+}
+
+bool HHAnalyzer::sameEndCap(const LorentzVector& p1, const LorentzVector& p2) {
+    return p1.Eta() * p2.Eta() > 0 && std::abs(p1.Eta()) > 1.24 && std::abs(p2.Eta()) > 1.24;
+}
+
+float HHAnalyzer::translatePhi(float phi, float translation/*=0*/) {
+    phi += translation; // translate
+    phi = std::fmod(phi, 2 * M_PI); // put between -2pi, 2pi
+    phi = (phi > 0) ? phi : (2 * M_PI + phi); // put between 0, 2pi
+    return phi;
+}
+
+int HHAnalyzer::getPhiSector(float phi, float start, float end) {
+    for (int i = 0; i < 6; i++) {
+        if (start + i * M_PI / 3 <= phi && phi < end + i * M_PI / 3)
+            return i;
+    }
+    return -1;
+}
+
+bool HHAnalyzer::isCSCSameSector(const Lepton& lep1, const Lepton& lep2) {
+    if (!sameEndCap(lep1.p4, lep2.p4))
+        return false;
+
+    float phi1 = translatePhi(getL1TPhi(lep1.charge, lep1.p4));
+    float phi2 = translatePhi(getL1TPhi(lep2.charge, lep2.p4));
+
+    int sector1 = getPhiSector(phi1, 15*M_PI/180, 65*M_PI/180);
+    int sector2 = getPhiSector(phi2, 15*M_PI/180, 65*M_PI/180);
+
+    int overlap1 = getPhiSector(phi1, 5*M_PI/180, 15*M_PI/180);
+    int overlap2 = getPhiSector(phi2, 5*M_PI/180, 15*M_PI/180);
+
+    if (sector1 >= 0 && sector2 >= 0 && sector1 == sector2)
+        return true;
+
+    if (overlap1 >= 0 && overlap2 >= 0 && overlap1 == overlap2)
+        return true;
+
+    return false;
+}
+
+bool HHAnalyzer::isCSCWithOverlap(const Lepton& lep1, const Lepton& lep2) {
+    if (!sameEndCap(lep1.p4, lep2.p4))
+        return false;
+
+    float phi1 = translatePhi(getL1TPhi(lep1.charge, lep1.p4));
+    float phi2 = translatePhi(getL1TPhi(lep2.charge, lep2.p4));
+
+    int sector1 = getPhiSector(phi1, 15*M_PI/180, 55*M_PI/180);
+    int sector2 = getPhiSector(phi2, 15*M_PI/180, 55*M_PI/180);
+
+    int overlap1 = getPhiSector(phi1, 5*M_PI/180, 15*M_PI/180);
+    int overlap2 = getPhiSector(phi2, 5*M_PI/180, 15*M_PI/180);
+
+    if (sector1 >= 0 && overlap2 >= 0 && sector1 == overlap2)
+        return true;
+
+    if (sector2 >= 0 && overlap1 >= 0 && sector2 == overlap1)
+        return true;
+
+    return false;
+}
+
 void HHAnalyzer::fillTriggerEfficiencies(const Lepton & lep1, const Lepton & lep2, Dilepton & dilep) {
 
     float eff_lep1_leg1 = 1.;
@@ -355,16 +425,6 @@ void HHAnalyzer::fillTriggerEfficiencies(const Lepton & lep1, const Lepton & lep
 
     // See https://cp3-llbb.slack.com/archives/hh/p1486566100001301
     constexpr float L1_EMTF_bug_eff_MuMu = 0.5265;
-    auto getMuonsSector = [](const LorentzVector& mu) -> int {
-        float phi = mu.Phi();
-        float phiPositive = (phi > 0) ? phi : (2 * M_PI + phi);
-        float phiTranslated = (phiPositive - M_PI / 12) > 0 ? (phiPositive - M_PI / 12) : (23 * M_PI / 12 + phiPositive);
-        int phiSector = static_cast<int>(floor(phiTranslated / (M_PI / 3)));
-        return phiSector;
-    };
-    auto sameEndcap = [](const LorentzVector& p1, const LorentzVector& p2) -> bool {
-        return p1.Eta() * p2.Eta() > 0 && std::abs(p1.Eta()) > 1.2 && std::abs(p2.Eta()) > 1.2;
-    };
 
     float DZ_filter_eff = 1.;
 
@@ -377,10 +437,9 @@ void HHAnalyzer::fillTriggerEfficiencies(const Lepton & lep1, const Lepton & lep
         eff_lep2_leg1 = m_hlt_efficiencies.at("IsoMu17leg")->get(p_hlt_lep2)[0];
         eff_lep2_leg2 = m_hlt_efficiencies.at("IsoMu8orIsoTkMu8leg")->get(p_hlt_lep2)[0];
         DZ_filter_eff = DZ_filter_eff_MuMu;
-        // L1 EMTF bug
-        if (getMuonsSector(lep1.p4) == getMuonsSector(lep2.p4) && sameEndcap(lep1.p4, lep2.p4)) {
+        // FIXME L1 EMTF bug
+        if (isCSCSameSector(lep1, lep2))
             DZ_filter_eff *= L1_EMTF_bug_eff_MuMu;
-        }
     }
     else if (lep1.isMu && lep2.isEl) {
         eff_lep1_leg1 = m_hlt_efficiencies.at("IsoMu23leg")->get(p_hlt_lep1)[0];

--- a/test/HHConfiguration.py
+++ b/test/HHConfiguration.py
@@ -17,6 +17,8 @@ if runOnData :
 
 framework = Framework.Framework(runOnData, eras.Run2_25ns, globalTag=globalTag_, processName=processName_)
 
+process.framework.treeFlushSize = cms.untracked.uint64(5 * 1024 * 1024)
+
 framework.addAnalyzer('hh_analyzer', cms.PSet(
         type = cms.string('hh_analyzer'),
         prefix = cms.string('hh_'),


### PR DESCRIPTION
Using the angular definitions at: https://twiki.cern.ch/twiki/bin/view/CMS/EndcapHighPtMuonEfficiencyProblem

Case 2) -> apply 52% efficiency on MC
Case 3) -> reject event (both data and MC)

The formula for the Phi propagation still needs to be confirmed, so no merging until then!