### PR TITLE
L1 muon bug: only cut if it's a run affected by the bug

### DIFF
--- a/plugins/HHAnalyzer.cc
+++ b/plugins/HHAnalyzer.cc
@@ -442,9 +442,17 @@ void HHAnalyzer::analyze(const edm::Event& event, const edm::EventSetup&, const 
             if (!dilep.isOS)
                 continue;
 
-            // FIXME L1 EMTF bug mitigation -- cut the overlap on both MC and data
-            if (dilep.isMuMu && isCSCWithOverlap(leptons[ilep1], leptons[ilep2]))
-                continue;
+            // FIXME L1 EMTF bug mitigation -- cut the overlap on data if it's a run affected by the bug
+            // On MC, apply the fraction of lumi the bug was not present
+            if (dilep.isMuMu && isCSCWithOverlap(leptons[ilep1], leptons[ilep2])) {
+                if (event.isRealData() && fwevent.run < 278167) {
+                    continue;
+                } else if (!event.isRealData()) {
+                   dilep.trigger_efficiency *= 0.5265;
+                   dilep.trigger_efficiency_downVariated *= 0.5265;
+                   dilep.trigger_efficiency_upVariated *= 0.5265;
+                }
+            }
 
             // Throw event if there is no matched dilepton trigger path (only on data)
             if (event.isRealData()


### PR DESCRIPTION
We don't need to throw events if we know the issue wasn't present, and it was fixed starting from run 278167. That way we also don't throw MC but simply weigh them as we do in the other case.